### PR TITLE
feat(web): SSE client + live dashboard updates with mock transport

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -33,6 +33,8 @@ tags:
     description: Past and in-progress scenario executions
   - name: Metrics
     description: Time-series telemetry
+  - name: Events
+    description: Server-Sent Events stream for live updates
   - name: Docs
     description: Self-describing API — the spec and browsable docs
 
@@ -217,6 +219,72 @@ paths:
                 $ref: '#/components/schemas/ExecutionPage'
         default:
           $ref: '#/components/responses/Problem'
+
+  /executions/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdPath'
+    get:
+      tags: [Executions]
+      operationId: getExecution
+      summary: Get a single execution with its full step-by-step detail
+      description: |
+        Returns the full execution detail including every completed step so
+        far. For running executions this represents a point-in-time
+        snapshot; subsequent state is delivered via the SSE
+        `execution.progress` event which carries the same shape.
+      responses:
+        '200':
+          description: Execution detail
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Execution'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/Problem'
+
+  /events:
+    get:
+      tags: [Events]
+      operationId: subscribeEvents
+      summary: Server-Sent Events stream of live updates
+      description: |
+        Opens a long-lived SSE stream of server → client events. The
+        connection stays open; the server pushes `text/event-stream`
+        records as state changes.
+
+        ### Contract
+
+        Every event carries the **full current state** of the resource it
+        concerns. Clients can treat each event as a last-write-wins
+        replacement — missed events do not need to be replayed because the
+        next event for the same resource supersedes them. Reconnection is
+        automatic (the browser `EventSource` does this natively); on
+        reconnect the client should invalidate its caches so the next
+        paint reads truth from REST.
+
+        ### Event types
+
+        | `event:` field | Payload schema | Notes |
+        |---|---|---|
+        | `peer.updated` | `Peer` | Any status transition, rename, etc. |
+        | `execution.created` | `ExecutionSummary` | A new execution has started. |
+        | `execution.progress` | `Execution` | A running execution advanced. Includes *all* completed steps so far. Terminal events carry `result: success\|failure`. |
+        | `dashboard.kpi` | `DashboardKpis` | Aggregate counters changed. |
+
+        OpenAPI does not model SSE richly, so this operation documents the
+        connection point only; per-event payload shapes are the referenced
+        component schemas above.
+      responses:
+        '200':
+          description: Event stream opened
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                description: |
+                  SSE stream. Each record is `event: <type>\ndata: <json>\n\n`.
 
   /metrics/response-time:
     get:
@@ -511,6 +579,63 @@ components:
             $ref: '#/components/schemas/ExecutionSummary'
         page:
           $ref: '#/components/schemas/PageMeta'
+
+    ExecutionStep:
+      type: object
+      description: One step of a scenario execution.
+      required: [n, name, result]
+      properties:
+        n:
+          type: integer
+          minimum: 1
+          description: 1-based sequence number of the step
+        name:
+          type: string
+          description: Short step name (e.g. 'CCR-I', 'CCR-U')
+        result:
+          $ref: '#/components/schemas/ExecutionResult'
+        startedAt:
+          type: string
+          format: date-time
+        finishedAt:
+          type: string
+          format: date-time
+          description: Present only when the step has completed
+        durationMs:
+          type: integer
+          minimum: 0
+          description: Wall-clock duration in milliseconds (present when finished)
+        errorDetail:
+          type: string
+          description: Human-readable error when `result=failure`
+
+    Execution:
+      description: |
+        Full execution detail. Extends `ExecutionSummary` with step-by-step
+        progress. This is the payload returned by `GET /executions/{id}`
+        and carried by every SSE `execution.progress` event.
+      allOf:
+        - $ref: '#/components/schemas/ExecutionSummary'
+        - type: object
+          required: [currentStep, totalSteps, steps]
+          properties:
+            currentStep:
+              type: integer
+              minimum: 0
+              description: |
+                0-based index of the step currently executing, or equal to
+                `totalSteps` when the execution has completed.
+            totalSteps:
+              type: integer
+              minimum: 0
+            steps:
+              type: array
+              description: |
+                All steps completed so far. For running executions this
+                grows as the scenario advances; terminal executions contain
+                every step in the scenario.
+              items:
+                $ref: '#/components/schemas/ExecutionStep'
 
     # ─────────────── Metrics ───────────────
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { Route, Routes } from 'react-router';
 
 import { createQueryClient } from './api/query-client';
+import { SseProvider } from './api/sse/SseProvider';
 import { ErrorProvider } from './context/error/ErrorProvider';
 import { theme } from './theme/theme';
 import { AppShell } from './layout/AppShell';
@@ -17,8 +18,9 @@ export function App() {
     <ErrorProvider>
       <MantineProvider theme={theme} defaultColorScheme="auto">
         <QueryClientProvider client={queryClient}>
-          <Notifications position="top-right" />
-          <Routes>
+          <SseProvider>
+            <Notifications position="top-right" />
+            <Routes>
             <Route element={<AppShell />}>
               <Route index element={<DashboardPage />} />
               <Route path="peers" element={<PlaceholderPage title="Peers" />} />
@@ -44,6 +46,7 @@ export function App() {
               />
             </Route>
           </Routes>
+          </SseProvider>
         </QueryClientProvider>
       </MantineProvider>
     </ErrorProvider>

--- a/web/src/api/resources/executions.ts
+++ b/web/src/api/resources/executions.ts
@@ -7,6 +7,8 @@ export type ExecutionSummary = components['schemas']['ExecutionSummary'];
 export type ExecutionPage = components['schemas']['ExecutionPage'];
 export type ExecutionMode = components['schemas']['ExecutionMode'];
 export type ExecutionResult = components['schemas']['ExecutionResult'];
+export type Execution = components['schemas']['Execution'];
+export type ExecutionStep = components['schemas']['ExecutionStep'];
 
 export interface ListExecutionsParams {
   status?: ExecutionResult;
@@ -18,6 +20,7 @@ export const executionKeys = {
   all: ['executions'] as const,
   list: (params: ListExecutionsParams = {}) =>
     [...executionKeys.all, 'list', params] as const,
+  detail: (id: string) => [...executionKeys.all, 'detail', id] as const,
 };
 
 export const listExecutions = (
@@ -29,9 +32,22 @@ export const listExecutions = (
     signal,
   });
 
+export const getExecution = (id: string, signal?: AbortSignal) =>
+  ApiService.get<Execution>(`/executions/${encodeURIComponent(id)}`, {
+    signal,
+  });
+
 export function useExecutions(params: ListExecutionsParams = {}) {
   return useQuery({
     queryKey: executionKeys.list(params),
     queryFn: ({ signal }) => listExecutions(params, signal),
+  });
+}
+
+export function useExecution(id: string) {
+  return useQuery({
+    queryKey: executionKeys.detail(id),
+    queryFn: ({ signal }) => getExecution(id, signal),
+    enabled: Boolean(id),
   });
 }

--- a/web/src/api/schema.d.ts
+++ b/web/src/api/schema.d.ts
@@ -189,6 +189,77 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/executions/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Resource identifier */
+                id: components["parameters"]["IdPath"];
+            };
+            cookie?: never;
+        };
+        /**
+         * Get a single execution with its full step-by-step detail
+         * @description Returns the full execution detail including every completed step so
+         *     far. For running executions this represents a point-in-time
+         *     snapshot; subsequent state is delivered via the SSE
+         *     `execution.progress` event which carries the same shape.
+         */
+        get: operations["getExecution"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Server-Sent Events stream of live updates
+         * @description Opens a long-lived SSE stream of server → client events. The
+         *     connection stays open; the server pushes `text/event-stream`
+         *     records as state changes.
+         *
+         *     ### Contract
+         *
+         *     Every event carries the **full current state** of the resource it
+         *     concerns. Clients can treat each event as a last-write-wins
+         *     replacement — missed events do not need to be replayed because the
+         *     next event for the same resource supersedes them. Reconnection is
+         *     automatic (the browser `EventSource` does this natively); on
+         *     reconnect the client should invalidate its caches so the next
+         *     paint reads truth from REST.
+         *
+         *     ### Event types
+         *
+         *     | `event:` field | Payload schema | Notes |
+         *     |---|---|---|
+         *     | `peer.updated` | `Peer` | Any status transition, rename, etc. |
+         *     | `execution.created` | `ExecutionSummary` | A new execution has started. |
+         *     | `execution.progress` | `Execution` | A running execution advanced. Includes *all* completed steps so far. Terminal events carry `result: success\|failure`. |
+         *     | `dashboard.kpi` | `DashboardKpis` | Aggregate counters changed. |
+         *
+         *     OpenAPI does not model SSE richly, so this operation documents the
+         *     connection point only; per-event payload shapes are the referenced
+         *     component schemas above.
+         */
+        get: operations["subscribeEvents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/metrics/response-time": {
         parameters: {
             query?: never;
@@ -328,6 +399,44 @@ export interface components {
         ExecutionPage: {
             items: components["schemas"]["ExecutionSummary"][];
             page: components["schemas"]["PageMeta"];
+        };
+        /** @description One step of a scenario execution. */
+        ExecutionStep: {
+            /** @description 1-based sequence number of the step */
+            n: number;
+            /** @description Short step name (e.g. 'CCR-I', 'CCR-U') */
+            name: string;
+            result: components["schemas"]["ExecutionResult"];
+            /** Format: date-time */
+            startedAt?: string;
+            /**
+             * Format: date-time
+             * @description Present only when the step has completed
+             */
+            finishedAt?: string;
+            /** @description Wall-clock duration in milliseconds (present when finished) */
+            durationMs?: number;
+            /** @description Human-readable error when `result=failure` */
+            errorDetail?: string;
+        };
+        /**
+         * @description Full execution detail. Extends `ExecutionSummary` with step-by-step
+         *     progress. This is the payload returned by `GET /executions/{id}`
+         *     and carried by every SSE `execution.progress` event.
+         */
+        Execution: components["schemas"]["ExecutionSummary"] & {
+            /**
+             * @description 0-based index of the step currently executing, or equal to
+             *     `totalSteps` when the execution has completed.
+             */
+            currentStep: number;
+            totalSteps: number;
+            /**
+             * @description All steps completed so far. For running executions this
+             *     grows as the scenario advances; terminal executions contain
+             *     every step in the scenario.
+             */
+            steps: components["schemas"]["ExecutionStep"][];
         };
         ResponseTimePoint: {
             /**
@@ -613,6 +722,51 @@ export interface operations {
                 };
             };
             default: components["responses"]["Problem"];
+        };
+    };
+    getExecution: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Resource identifier */
+                id: components["parameters"]["IdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Execution detail */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Execution"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            default: components["responses"]["Problem"];
+        };
+    };
+    subscribeEvents: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Event stream opened */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/event-stream": string;
+                };
+            };
         };
     };
     getResponseTimeSeries: {

--- a/web/src/api/sse/SseClient.ts
+++ b/web/src/api/sse/SseClient.ts
@@ -1,0 +1,127 @@
+import type { SseEvent } from './events';
+import { SSE_EVENT_TYPES } from './events';
+import type { EventStreamLike } from './transport';
+import { openEventStream } from './transport';
+
+export type SseStatus = 'idle' | 'connecting' | 'open' | 'closed';
+
+type EventHandler = (event: SseEvent) => void;
+type StatusHandler = (status: SseStatus) => void;
+
+interface SseClientOptions {
+  url: string;
+  /** Called for every decoded event, regardless of type. */
+  onEvent: EventHandler;
+  /** Called when the connection status changes. Optional. */
+  onStatus?: StatusHandler;
+  /**
+   * Called once the underlying `EventSource` reports `error` at a moment
+   * when the browser will auto-reconnect. Use it to invalidate caches so
+   * the next paint is re-fetched truth.
+   */
+  onReconnectHint?: () => void;
+}
+
+/**
+ * Thin wrapper around an `EventSource`-like stream.
+ *
+ * - Multiplexes typed events onto a single `onEvent` callback
+ * - Exposes a status lifecycle (`idle → connecting → open → closed`)
+ * - Delegates reconnection to the underlying transport (browsers do this
+ *   natively for `EventSource`); on each transient error we emit a
+ *   reconnect hint so callers can invalidate their caches.
+ *
+ * The client owns one stream at a time. Call `close()` before re-opening.
+ */
+export class SseClient {
+  private readonly opts: SseClientOptions;
+  private stream: EventStreamLike | undefined;
+  private status: SseStatus = 'idle';
+  private readonly listeners = new Map<
+    string,
+    (ev: MessageEvent) => void
+  >();
+  private openListener: (() => void) | undefined;
+  private errorListener: (() => void) | undefined;
+
+  constructor(opts: SseClientOptions) {
+    this.opts = opts;
+  }
+
+  open(): void {
+    if (this.stream) return;
+    this.setStatus('connecting');
+    const stream = openEventStream(this.opts.url);
+    this.stream = stream;
+
+    // Native EventSource fires a generic "open"/"error" on the instance;
+    // our minimal interface doesn't model them, so we cast.
+    const raw = stream as unknown as {
+      addEventListener: (
+        type: string,
+        handler: (ev: Event | MessageEvent) => void,
+      ) => void;
+    };
+
+    this.openListener = () => this.setStatus('open');
+    this.errorListener = () => {
+      // `EventSource` auto-reconnects on transient errors. If readyState
+      // drops to CLOSED (2) the connection is terminal.
+      if (stream.readyState === 2) {
+        this.setStatus('closed');
+      } else {
+        this.setStatus('connecting');
+        this.opts.onReconnectHint?.();
+      }
+    };
+
+    raw.addEventListener('open', this.openListener);
+    raw.addEventListener('error', this.errorListener);
+
+    for (const type of SSE_EVENT_TYPES) {
+      const listener = (ev: MessageEvent) => {
+        try {
+          const data = JSON.parse(ev.data);
+          this.opts.onEvent({ type, data } as SseEvent);
+        } catch (err) {
+          // A malformed event should never kill the stream — log and drop.
+          console.warn(`[sse] dropped malformed ${type} event`, err);
+        }
+      };
+      this.listeners.set(type, listener);
+      stream.addEventListener(type, listener);
+    }
+  }
+
+  close(): void {
+    const stream = this.stream;
+    if (!stream) return;
+
+    for (const [type, listener] of this.listeners) {
+      stream.removeEventListener(type, listener);
+    }
+    this.listeners.clear();
+
+    const raw = stream as unknown as {
+      removeEventListener: (type: string, handler: () => void) => void;
+    };
+    if (this.openListener) raw.removeEventListener('open', this.openListener);
+    if (this.errorListener) raw.removeEventListener('error', this.errorListener);
+    this.openListener = undefined;
+    this.errorListener = undefined;
+
+    stream.close();
+    this.stream = undefined;
+    this.setStatus('closed');
+  }
+
+  getStatus(): SseStatus {
+    return this.status;
+  }
+
+  private setStatus(next: SseStatus): void {
+    if (this.status === next) return;
+    this.status = next;
+    this.opts.onStatus?.(next);
+  }
+}

--- a/web/src/api/sse/SseContext.ts
+++ b/web/src/api/sse/SseContext.ts
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react';
+
+import type { SseStatus } from './SseClient';
+
+export interface SseContextValue {
+  status: SseStatus;
+}
+
+export const SseContext = createContext<SseContextValue>({ status: 'idle' });
+
+export function useSseStatus(): SseStatus {
+  return useContext(SseContext).status;
+}

--- a/web/src/api/sse/SseProvider.tsx
+++ b/web/src/api/sse/SseProvider.tsx
@@ -1,0 +1,51 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+
+import { appConfig } from '../../config/app';
+import { applyEventToCache } from './applyEventToCache';
+import { SseContext, type SseContextValue } from './SseContext';
+import { SseClient, type SseStatus } from './SseClient';
+
+interface SseProviderProps {
+  children: ReactNode;
+  /** Override the SSE endpoint. Defaults to `${apiBaseUrl}/events`. */
+  url?: string;
+}
+
+/**
+ * Owns a single SSE connection for the app and fans events out to the
+ * TanStack Query cache.
+ *
+ * Integration model (per ARCHITECTURE.md §9):
+ * - Every event payload is the **full current state** of its resource.
+ * - We `setQueryData` for detail/KPI caches so the UI updates instantly.
+ * - We patch list caches where we know the shape; otherwise invalidate.
+ * - On transient reconnection, we invalidate everything so the next paint
+ *   reads truth from REST and converges on any missed state.
+ */
+export function SseProvider({ children, url }: SseProviderProps) {
+  const queryClient = useQueryClient();
+  const [status, setStatus] = useState<SseStatus>('idle');
+
+  const resolvedUrl = url ?? `${appConfig.apiBaseUrl}/events`;
+
+  useEffect(() => {
+    const client = new SseClient({
+      url: resolvedUrl,
+      onStatus: setStatus,
+      onReconnectHint: () => {
+        // Browser reconnects automatically; nudge the cache so the first
+        // post-reconnect paint is guaranteed fresh.
+        queryClient.invalidateQueries();
+      },
+      onEvent: (event) => applyEventToCache(queryClient, event),
+    });
+    client.open();
+    return () => client.close();
+    // resolvedUrl and queryClient are stable for the app's lifetime
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const value = useMemo<SseContextValue>(() => ({ status }), [status]);
+  return <SseContext.Provider value={value}>{children}</SseContext.Provider>;
+}

--- a/web/src/api/sse/applyEventToCache.ts
+++ b/web/src/api/sse/applyEventToCache.ts
@@ -1,0 +1,92 @@
+import type { QueryClient } from '@tanstack/react-query';
+
+import { dashboardKeys, type DashboardKpis } from '../resources/dashboard';
+import {
+  executionKeys,
+  type Execution,
+  type ExecutionPage,
+  type ExecutionSummary,
+} from '../resources/executions';
+import { peerKeys, type Peer } from '../resources/peers';
+import type { SseEvent } from './events';
+
+/**
+ * Apply a decoded SSE event to the React Query cache.
+ *
+ * Kept as a pure function (no React) so it can be unit-tested without
+ * mounting a component tree.
+ */
+export function applyEventToCache(
+  queryClient: QueryClient,
+  event: SseEvent,
+): void {
+  switch (event.type) {
+    case 'peer.updated':
+      applyPeerUpdated(queryClient, event.data);
+      return;
+
+    case 'execution.progress':
+      applyExecutionProgress(queryClient, event.data);
+      return;
+
+    case 'execution.created':
+      // New row → refetch the list; detail queries for unknown ids aren't
+      // mounted yet so no detail cache to seed.
+      queryClient.invalidateQueries({ queryKey: executionKeys.all });
+      return;
+
+    case 'dashboard.kpi':
+      queryClient.setQueryData<DashboardKpis>(
+        dashboardKeys.kpis(),
+        event.data,
+      );
+      return;
+  }
+}
+
+function applyPeerUpdated(queryClient: QueryClient, peer: Peer): void {
+  // Seed / refresh the detail cache.
+  queryClient.setQueryData<Peer>(peerKeys.detail(peer.id), peer);
+
+  // Patch the list cache in place — no refetch needed.
+  queryClient.setQueryData<Peer[]>(peerKeys.list(), (prev) => {
+    if (!prev) return prev;
+    const idx = prev.findIndex((p) => p.id === peer.id);
+    if (idx === -1) return [...prev, peer];
+    const next = prev.slice();
+    next[idx] = peer;
+    return next;
+  });
+}
+
+function applyExecutionProgress(
+  queryClient: QueryClient,
+  execution: Execution,
+): void {
+  // Detail cache — full replace.
+  queryClient.setQueryData<Execution>(
+    executionKeys.detail(execution.id),
+    execution,
+  );
+
+  // Patch every list cache we've got (each `status` filter is its own key).
+  queryClient.setQueriesData<ExecutionPage>(
+    { queryKey: executionKeys.all },
+    (prev) => {
+      if (!prev || !Array.isArray(prev.items)) return prev;
+      const summary: ExecutionSummary = toSummary(execution);
+      const idx = prev.items.findIndex((e) => e.id === execution.id);
+      if (idx === -1) return prev;
+      const items = prev.items.slice();
+      items[idx] = summary;
+      return { ...prev, items };
+    },
+  );
+}
+
+/** Strip an `Execution` back down to its `ExecutionSummary` fields. */
+function toSummary(execution: Execution): ExecutionSummary {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { currentStep, totalSteps, steps, ...summary } = execution;
+  return summary;
+}

--- a/web/src/api/sse/events.ts
+++ b/web/src/api/sse/events.ts
@@ -1,0 +1,26 @@
+import type { DashboardKpis } from '../resources/dashboard';
+import type {
+  Execution,
+  ExecutionSummary,
+} from '../resources/executions';
+import type { Peer } from '../resources/peers';
+
+/**
+ * Discriminated union of every SSE event the server may emit. The `type`
+ * field mirrors the SSE `event:` header and keys the payload shape.
+ *
+ * Adding a new event = add a member here + a handler in `SseProvider`.
+ */
+export type SseEvent =
+  | { type: 'peer.updated'; data: Peer }
+  | { type: 'execution.created'; data: ExecutionSummary }
+  | { type: 'execution.progress'; data: Execution }
+  | { type: 'dashboard.kpi'; data: DashboardKpis };
+
+/** All known event-type strings — handy for iterating subscriptions. */
+export const SSE_EVENT_TYPES: SseEvent['type'][] = [
+  'peer.updated',
+  'execution.created',
+  'execution.progress',
+  'dashboard.kpi',
+];

--- a/web/src/api/sse/transport.ts
+++ b/web/src/api/sse/transport.ts
@@ -1,0 +1,39 @@
+/**
+ * Minimal `EventSource`-compatible interface the SSE client depends on.
+ *
+ * We don't use the full DOM `EventSource` type so that the mock transport
+ * (used when `VITE_USE_MOCK_API` is on) can provide an in-memory emitter
+ * without having to subclass the real thing.
+ */
+export interface EventStreamLike {
+  addEventListener(type: string, listener: (ev: MessageEvent) => void): void;
+  removeEventListener(type: string, listener: (ev: MessageEvent) => void): void;
+  close(): void;
+  /** 0 = CONNECTING, 1 = OPEN, 2 = CLOSED (matches the DOM spec). */
+  readonly readyState: number;
+}
+
+export type EventStreamFactory = (url: string) => EventStreamLike;
+
+const nativeFactory: EventStreamFactory = (url) =>
+  new EventSource(url) as unknown as EventStreamLike;
+
+let factory: EventStreamFactory = nativeFactory;
+
+/** Open an event stream using the currently-registered factory. */
+export function openEventStream(url: string): EventStreamLike {
+  return factory(url);
+}
+
+/**
+ * Replace the factory. Used by the mock layer to install an in-memory
+ * emitter when the mock API is enabled.
+ */
+export function setEventStreamFactory(fn: EventStreamFactory): void {
+  factory = fn;
+}
+
+/** Restore the native `EventSource` factory. Exposed for tests. */
+export function resetEventStreamFactory(): void {
+  factory = nativeFactory;
+}

--- a/web/src/mocks/data/executionDetails.ts
+++ b/web/src/mocks/data/executionDetails.ts
@@ -1,0 +1,124 @@
+import type {
+  Execution,
+  ExecutionStep,
+} from '../../api/resources/executions';
+import { executionFixtures } from './executions';
+
+/**
+ * Canonical 12-step Diameter scenario template. Real scenarios would vary
+ * per-execution, but for MVP every execution uses the same outline and
+ * failures are injected by swapping one step's result to `failure`.
+ */
+const STEP_TEMPLATE = [
+  'CER',
+  'CEA',
+  'CCR-I',
+  'CCA-I',
+  'CCR-U (1)',
+  'CCA-U (1)',
+  'CCR-U (2)',
+  'CCA-U (2)',
+  'CCR-U (3)',
+  'CCA-U (3)',
+  'CCR-T',
+  'CCA-T',
+];
+
+function buildCompletedSteps(
+  startedAtMs: number,
+  finishedAtMs: number,
+  outcome: 'success' | 'failure',
+): ExecutionStep[] {
+  const total = STEP_TEMPLATE.length;
+  const span = Math.max(1, finishedAtMs - startedAtMs);
+  const bucket = Math.floor(span / total);
+  // For failures, flip the last step to failure so the step list reads naturally.
+  return STEP_TEMPLATE.map((name, i): ExecutionStep => {
+    const started = startedAtMs + i * bucket;
+    const finished = i === total - 1 ? finishedAtMs : started + bucket;
+    const isTerminalFail = outcome === 'failure' && i === total - 1;
+    return {
+      n: i + 1,
+      name,
+      result: isTerminalFail ? 'failure' : 'success',
+      startedAt: new Date(started).toISOString(),
+      finishedAt: new Date(finished).toISOString(),
+      durationMs: finished - started,
+      ...(isTerminalFail
+        ? { errorDetail: 'DIAMETER_UNABLE_TO_COMPLY (5012)' }
+        : {}),
+    };
+  });
+}
+
+function buildRunningSteps(
+  startedAtMs: number,
+  completedSoFar: number,
+): ExecutionStep[] {
+  const out: ExecutionStep[] = [];
+  let cursor = startedAtMs;
+  for (let i = 0; i < completedSoFar; i++) {
+    const duration = 20 + ((i * 7) % 35); // deterministic-ish jitter
+    const started = cursor;
+    const finished = cursor + duration;
+    out.push({
+      n: i + 1,
+      name: STEP_TEMPLATE[i],
+      result: 'success',
+      startedAt: new Date(started).toISOString(),
+      finishedAt: new Date(finished).toISOString(),
+      durationMs: duration,
+    });
+    cursor = finished;
+  }
+  return out;
+}
+
+/**
+ * Build a full `Execution` detail record from a summary. Running executions
+ * get a partial `steps` array; completed executions get all 12.
+ *
+ * `completedStepsForRunning` lets the mock SSE emitter advance a running
+ * execution by calling this with incrementing values.
+ */
+export function buildExecutionDetail(
+  id: string,
+  completedStepsForRunning?: number,
+): Execution | undefined {
+  const summary = executionFixtures.find((e) => e.id === id);
+  if (!summary) return undefined;
+
+  if (summary.result === 'running') {
+    const startedAtMs = Date.parse(summary.startedAt);
+    const completed = completedStepsForRunning ?? defaultRunningProgress(id);
+    const steps = buildRunningSteps(startedAtMs, completed);
+    return {
+      ...summary,
+      currentStep: completed,
+      totalSteps: STEP_TEMPLATE.length,
+      steps,
+    };
+  }
+
+  const startedAtMs = Date.parse(summary.startedAt);
+  const finishedAtMs = Date.parse(summary.finishedAt ?? summary.startedAt);
+  return {
+    ...summary,
+    currentStep: STEP_TEMPLATE.length,
+    totalSteps: STEP_TEMPLATE.length,
+    steps: buildCompletedSteps(
+      startedAtMs,
+      finishedAtMs,
+      summary.result === 'failure' ? 'failure' : 'success',
+    ),
+  };
+}
+
+/** Initial "how many steps done" for each running fixture at load time. */
+function defaultRunningProgress(id: string): number {
+  if (id === '43') return 4;
+  if (id === '44') return 1;
+  return 0;
+}
+
+export const TOTAL_STEPS = STEP_TEMPLATE.length;

--- a/web/src/mocks/fakeApi/executionsFakeApi.ts
+++ b/web/src/mocks/fakeApi/executionsFakeApi.ts
@@ -1,10 +1,13 @@
 import type {
+  Execution,
   ExecutionPage,
   ExecutionResult,
 } from '../../api/resources/executions';
+import { buildExecutionDetail } from '../data/executionDetails';
 import { executionFixtures } from '../data/executions';
 import { mock } from '../MockAdapter';
 
+// List endpoint — note regex anchors so /executions/:id doesn't match here.
 mock
   .onGet(/\/executions(\?|$)/)
   .withDelayInMs(250)
@@ -25,4 +28,24 @@ mock
         page: { total: filtered.length, limit, offset },
       },
     ];
+  });
+
+// Detail endpoint — /executions/{id}
+mock
+  .onGet(/\/executions\/[^/]+$/)
+  .withDelayInMs(200)
+  .reply((config): [number, Execution | { title: string; status: number }] => {
+    const url = config.url ?? '';
+    const id = decodeURIComponent(url.split('/').pop() ?? '');
+    const detail = buildExecutionDetail(id);
+    if (!detail) {
+      return [
+        404,
+        {
+          title: 'Execution not found',
+          status: 404,
+        },
+      ];
+    }
+    return [200, detail];
   });

--- a/web/src/mocks/index.ts
+++ b/web/src/mocks/index.ts
@@ -19,7 +19,12 @@ import './fakeApi/executionsFakeApi';
 import './fakeApi/metricsFakeApi';
 
 import { mock } from './MockAdapter';
+import { installMockSse } from './sse';
 
 // Anything that hasn't been explicitly mocked goes through to the real
 // backend. Prevents surprises as the spec grows.
 mock.onAny().passThrough();
+
+// Install the mock SSE transport so `new EventSource(...)` in the app
+// points at the in-memory emitter instead of the (non-existent) server.
+installMockSse();

--- a/web/src/mocks/sse.ts
+++ b/web/src/mocks/sse.ts
@@ -1,0 +1,195 @@
+import type { ExecutionSummary } from '../api/resources/executions';
+import type { Peer } from '../api/resources/peers';
+import type { EventStreamLike } from '../api/sse/transport';
+import { setEventStreamFactory } from '../api/sse/transport';
+import { buildExecutionDetail, TOTAL_STEPS } from './data/executionDetails';
+import { executionFixtures } from './data/executions';
+import { peerFixtures } from './data/peers';
+
+/** Tick cadence — fast enough to see the UI breathe, slow enough to read. */
+const EXECUTION_TICK_MS = 2_000;
+const PEER_FLIP_MS = 15_000;
+const KPI_TICK_MS = 5_000;
+
+/**
+ * In-memory `EventSource`-compatible emitter backed by timers. Registered
+ * as the SSE transport when `VITE_USE_MOCK_API` is on so the rest of the
+ * app can `new EventSource(...)` without caring whether it's real or not.
+ */
+class MockEventSource implements EventStreamLike {
+  private readonly listeners = new Map<string, Set<(ev: MessageEvent) => void>>();
+  private _readyState = 0;
+  private openTimer: ReturnType<typeof setTimeout> | undefined;
+  private readonly detach: () => void;
+
+  constructor() {
+    emitter.attach(this);
+    this.detach = () => emitter.detach(this);
+    // Defer "open" by a tick so listeners can subscribe first.
+    this.openTimer = setTimeout(() => {
+      this._readyState = 1;
+      this.dispatch('open', undefined);
+      emitter.sendInitialSnapshot(this);
+    }, 0);
+  }
+
+  get readyState(): number {
+    return this._readyState;
+  }
+
+  addEventListener(type: string, listener: (ev: MessageEvent) => void): void {
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    set.add(listener);
+  }
+
+  removeEventListener(
+    type: string,
+    listener: (ev: MessageEvent) => void,
+  ): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  close(): void {
+    if (this.openTimer) clearTimeout(this.openTimer);
+    this.openTimer = undefined;
+    this._readyState = 2;
+    this.listeners.clear();
+    this.detach();
+  }
+
+  /** Called by the emitter to push a typed event to this subscriber. */
+  dispatch(type: string, data: unknown): void {
+    const set = this.listeners.get(type);
+    if (!set || set.size === 0) return;
+    const payload = data === undefined ? '' : JSON.stringify(data);
+    const ev = new MessageEvent(type, { data: payload });
+    for (const listener of set) listener(ev);
+  }
+}
+
+/**
+ * Shared tick/broadcast hub. One instance per tab. Holds the current mock
+ * state (peer flip cycle, running execution progress) and fans every
+ * generated event out to every connected `MockEventSource`.
+ */
+class MockSseEmitter {
+  private readonly subscribers = new Set<MockEventSource>();
+  private peerTimer: ReturnType<typeof setInterval> | undefined;
+  private execTimer: ReturnType<typeof setInterval> | undefined;
+  private kpiTimer: ReturnType<typeof setInterval> | undefined;
+  /** Working copy of peers — mutated as status flips. */
+  private peers: Peer[] = peerFixtures.map((p) => ({ ...p }));
+  /** Working copy of executions — mutated as runs advance / finish. */
+  private executions: ExecutionSummary[] = executionFixtures.map((e) => ({
+    ...e,
+  }));
+  /** Per-running-execution progress counter (completed step count). */
+  private execProgress = new Map<string, number>([
+    ['43', 4],
+    ['44', 1],
+  ]);
+  /** Reusable toggle so peer-03 oscillates between error / connected. */
+  private peerFlipIsError = true;
+
+  attach(source: MockEventSource): void {
+    this.subscribers.add(source);
+    if (this.subscribers.size === 1) this.startTimers();
+  }
+
+  detach(source: MockEventSource): void {
+    this.subscribers.delete(source);
+    if (this.subscribers.size === 0) this.stopTimers();
+  }
+
+  /**
+   * Push the current state of everything to a just-connected subscriber so
+   * its caches are seeded immediately without waiting for the first tick.
+   */
+  sendInitialSnapshot(source: MockEventSource): void {
+    // No replay needed for MVP — REST already populated the caches. We
+    // still send a single `dashboard.kpi` so the "live" status indicator
+    // flips to OPEN with something visible in dev tools. Keep minimal.
+    source.dispatch('dashboard.kpi', this.computeKpis());
+  }
+
+  private startTimers(): void {
+    this.peerTimer = setInterval(() => this.flipPeer(), PEER_FLIP_MS);
+    this.execTimer = setInterval(() => this.tickExecutions(), EXECUTION_TICK_MS);
+    this.kpiTimer = setInterval(() => this.broadcastKpis(), KPI_TICK_MS);
+  }
+
+  private stopTimers(): void {
+    if (this.peerTimer) clearInterval(this.peerTimer);
+    if (this.execTimer) clearInterval(this.execTimer);
+    if (this.kpiTimer) clearInterval(this.kpiTimer);
+    this.peerTimer = this.execTimer = this.kpiTimer = undefined;
+  }
+
+  private broadcast(type: string, data: unknown): void {
+    for (const sub of this.subscribers) sub.dispatch(type, data);
+  }
+
+  /** Flip peer-03 between error/connected so the dashboard status breathes. */
+  private flipPeer(): void {
+    const peer = this.peers.find((p) => p.id === 'peer-03');
+    if (!peer) return;
+    this.peerFlipIsError = !this.peerFlipIsError;
+    peer.status = this.peerFlipIsError ? 'error' : 'connected';
+    peer.statusDetail = this.peerFlipIsError ? 'CER/CEA timeout' : undefined;
+    peer.lastChangeAt = new Date().toISOString();
+    this.broadcast('peer.updated', peer);
+    this.broadcast('dashboard.kpi', this.computeKpis());
+  }
+
+  /** Advance every running execution by one step; terminate at TOTAL_STEPS. */
+  private tickExecutions(): void {
+    for (const exec of this.executions) {
+      if (exec.result !== 'running') continue;
+      const soFar = this.execProgress.get(exec.id) ?? 0;
+      const next = soFar + 1;
+
+      if (next >= TOTAL_STEPS) {
+        // Terminal transition — mark success and emit a final progress
+        // event carrying the completed state.
+        exec.result = 'success';
+        exec.finishedAt = new Date().toISOString();
+        this.execProgress.set(exec.id, TOTAL_STEPS);
+        const detail = buildExecutionDetail(exec.id, TOTAL_STEPS);
+        if (detail) this.broadcast('execution.progress', detail);
+        this.broadcast('dashboard.kpi', this.computeKpis());
+      } else {
+        this.execProgress.set(exec.id, next);
+        const detail = buildExecutionDetail(exec.id, next);
+        if (detail) this.broadcast('execution.progress', detail);
+      }
+    }
+  }
+
+  private broadcastKpis(): void {
+    this.broadcast('dashboard.kpi', this.computeKpis());
+  }
+
+  private computeKpis() {
+    const connected = this.peers.filter((p) => p.status === 'connected').length;
+    const activeRuns = this.executions.filter((e) => e.result === 'running')
+      .length;
+    return {
+      peers: { connected, total: this.peers.length },
+      subscribers: 142,
+      templates: 8,
+      scenarios: 24,
+      activeRuns,
+    };
+  }
+}
+
+const emitter = new MockSseEmitter();
+
+/** Install the mock SSE factory. Called from `mocks/index.ts`. */
+export function installMockSse(): void {
+  setEventStreamFactory(() => new MockEventSource());
+}


### PR DESCRIPTION
## Summary

Adds the server-push layer so the Dashboard goes from \"static KPIs\" to \"live board\" without another PR round-trip. Pattern matches the decision from the previous discussion: every event carries full current state (last-write-wins), reconnection is native-browser, and on reconnect we invalidate caches so REST fills any gap.

### OpenAPI contract

- `Execution` (detail) + `ExecutionStep` schemas — detail extends `ExecutionSummary` with `currentStep`, `totalSteps`, `steps[]`.
- `GET /executions/{id}` — single-execution detail endpoint.
- `GET /events` — SSE stream; the description block documents the four event types and their payload shapes.

### Client SSE layer (`web/src/api/sse/`)

- **`transport.ts`** — pluggable `EventSource`-like factory. Native by default; mock layer swaps it.
- **`SseClient.ts`** — opens one stream, multiplexes by `event:` name, exposes an `idle/connecting/open/closed` status lifecycle, emits a reconnect hint so the caller can invalidate on transient drops.
- **`applyEventToCache.ts`** — pure function mapping `SseEvent → QueryClient` mutations. `setQueryData` for detail/KPI, patch-in-place for list caches, `invalidateQueries` for creations. Unit-testable without React.
- **`SseProvider.tsx` + `SseContext.ts` + `useSseStatus`** — mount once in `App.tsx`, fan events into the shared QueryClient.

### Mock transport (`web/src/mocks/sse.ts`)

- `MockEventSource` satisfies the transport interface.
- Shared `MockSseEmitter` with timers:
  - Flips peer-03 error↔connected every **15 s** (+ a KPI recompute).
  - Ticks each running execution forward one step every **2 s**, broadcasting the full `Execution` payload incl. all completed steps.
  - Terminal transition when an execution hits step 12: flip to `success` and emit a final `execution.progress` + `dashboard.kpi`.
  - KPI heartbeat every **5 s**.
- Dynamic import keeps it out of prod bundle.

### Mock REST

- `GET /executions/{id}` handler backed by a 12-step Diameter template fixture (\`CER → CEA → CCR-I → … → CCR-T → CCA-T\`). Builder produces either partial step lists for running execs or full for completed ones, so SSE and REST return identical shapes.

### Drive-by

- Hoisted SseClient's constructor-parameter-property to an explicit field assignment (TS 6's `erasableSyntaxOnly` rule forbids the shorthand).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm run dev` — watch peer-03 toggle error/connected every ~15 s; active-runs counter breathes as executions finish and KPI broadcasts update the tiles
- [ ] Open dev-tools Network: no `/api/v1/events` request (mock transport intercepts via factory)
- [ ] Temporarily set `VITE_USE_MOCK_API=false` and confirm the native `EventSource` factory is used (will fail to connect since no server yet — expected)

## Follow-ups (not in this PR)

- Go server-side `/events` handler with a broadcast hub.
- Connection status indicator in the top-bar (`useSseStatus`) — left out to keep the PR focused on the transport.
- Execution detail page that consumes `useExecution(id)` — next UI PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)