### PR TITLE
feat(web): peers UX polish — lifecycle toasts, stopped vs disconnected

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -204,21 +204,24 @@ paths:
         default:
           $ref: '#/components/responses/Problem'
 
-  /peers/{id}/connect:
+  /peers/{id}/start:
     parameters:
       - $ref: '#/components/parameters/IdPath'
     post:
       tags: [Peers]
-      operationId: connectPeer
-      summary: Initiate a connection to this peer
+      operationId: startPeer
+      summary: Start this peer (enable supervision + connect)
       description: |
-        Triggers a CER/CEA exchange and moves the peer towards `connected`.
-        Returns the updated `Peer` immediately — the status may still be
-        `connecting` when the response is returned; clients should react
-        to subsequent `peer.updated` SSE events for the final outcome.
+        Enables the supervision loop for this peer and triggers a CER/CEA
+        exchange. Moves the peer from `stopped` through `connecting` to
+        `connected` (or `error` / `disconnected` with ongoing retries if
+        the handshake fails). Returns the updated `Peer` immediately —
+        the status may still be `connecting` when the response is
+        returned; clients should react to subsequent `peer.updated` SSE
+        events for the final outcome.
       responses:
         '200':
-          description: Connection attempt started
+          description: Peer started
           content:
             application/json:
               schema:
@@ -228,21 +231,23 @@ paths:
         default:
           $ref: '#/components/responses/Problem'
 
-  /peers/{id}/disconnect:
+  /peers/{id}/stop:
     parameters:
       - $ref: '#/components/parameters/IdPath'
     post:
       tags: [Peers]
-      operationId: disconnectPeer
-      summary: Disconnect this peer
+      operationId: stopPeer
+      summary: Stop this peer (disable supervision + disconnect)
       description: |
-        Closes the Diameter transport. If `autoConnect` is true, the peer
-        will **not** be automatically reconnected — supervision only fires
-        at server startup. Use `POST /peers/{id}/connect` to reopen the
-        link explicitly.
+        Administratively stops this peer: disables the supervision loop
+        and closes the Diameter transport. The peer transitions to
+        `stopped` and will not retry. This is distinct from the
+        transport-level `disconnected` state (where supervision is still
+        active and will redial on its own). Use `POST /peers/{id}/start`
+        to resume.
       responses:
         '200':
-          description: Peer disconnected
+          description: Peer stopped
           content:
             application/json:
               schema:
@@ -592,7 +597,34 @@ components:
 
     PeerStatus:
       type: string
-      enum: [connected, connecting, disconnected, disconnecting, restarting, error]
+      description: |
+        Current runtime state of a peer.
+
+        - `stopped`       — Administratively down. Supervision is off; no
+                            reconnect attempts will be made. This is the
+                            default state for a freshly created peer.
+        - `disconnected`  — Supervision is on but the transport is down.
+                            The server will redial automatically.
+        - `connecting`    — CER/CEA exchange in progress.
+        - `connected`     — Session established.
+        - `disconnecting` — Graceful teardown in progress (admin-initiated).
+        - `restarting`    — Admin-initiated stop followed by start so a
+                            config change can take effect.
+        - `error`         — Supervision is on but the peer is in a
+                            persistent failure state (exponential backoff).
+
+        The distinction between `stopped` and `disconnected` is
+        deliberate: the former means "admin does not want this up"; the
+        latter means "admin wants this up but the transport is
+        currently down".
+      enum:
+        - stopped
+        - disconnected
+        - connecting
+        - connected
+        - disconnecting
+        - restarting
+        - error
 
     PeerTransport:
       type: string
@@ -637,10 +669,15 @@ components:
         autoConnect:
           type: boolean
           description: |
-            If true, the server attempts to connect this peer at server
-            startup. Does **not** trigger a connection when the peer is
-            created or updated mid-run — those require an explicit
-            `POST /peers/{id}/connect`.
+            Pure server-boot flag. When the server starts, peers with
+            `autoConnect: true` are automatically started (equivalent to
+            `POST /peers/{id}/start`); peers with `autoConnect: false`
+            remain `stopped` until the operator starts them.
+
+            This flag has **no bearing on current status**. A peer can
+            be `autoConnect: true` and `stopped` (the operator stopped
+            it after boot), or `autoConnect: false` and `connected`
+            (started manually during this run).
           default: true
         status:
           $ref: '#/components/schemas/PeerStatus'

--- a/web/src/api/resources/peers.ts
+++ b/web/src/api/resources/peers.ts
@@ -48,11 +48,11 @@ export const deletePeer = (id: string) =>
 export const testPeerConfig = (input: PeerInput) =>
   ApiService.post<PeerTestResult, PeerInput>('/peers/test', input);
 
-export const connectPeer = (id: string) =>
-  ApiService.post<Peer>(`/peers/${encodeURIComponent(id)}/connect`);
+export const startPeer = (id: string) =>
+  ApiService.post<Peer>(`/peers/${encodeURIComponent(id)}/start`);
 
-export const disconnectPeer = (id: string) =>
-  ApiService.post<Peer>(`/peers/${encodeURIComponent(id)}/disconnect`);
+export const stopPeer = (id: string) =>
+  ApiService.post<Peer>(`/peers/${encodeURIComponent(id)}/stop`);
 
 /**
  * Create a new peer. On success, invalidates the list so the new row
@@ -103,7 +103,7 @@ export function useTestPeerConfig() {
 }
 
 /**
- * Shared cache patcher for connect/disconnect — writes the returned peer into
+ * Shared cache patcher for start/stop — writes the returned peer into
  * the detail cache and patches the list row in place so the UI reflects the
  * new status without a refetch. SSE reconciles anything we missed.
  */
@@ -139,14 +139,15 @@ function optimisticStatusPatch(
 }
 
 /**
- * Explicitly connect a peer. Independent of `autoConnect`, which governs
- * server-startup behaviour only. Optimistically flips status to
- * `connecting` so the UI shows immediate feedback; rolls back on error.
+ * Explicitly start a peer (enable supervision + connect). Independent of
+ * `autoConnect`, which governs server-startup behaviour only.
+ * Optimistically flips status to `connecting` so the UI shows immediate
+ * feedback; rolls back on error.
  */
-export function useConnectPeer() {
+export function useStartPeer() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => connectPeer(id),
+    mutationFn: (id: string) => startPeer(id),
     onMutate: (id) => ({
       prev: optimisticStatusPatch(qc, id, 'connecting'),
       id,
@@ -159,14 +160,16 @@ export function useConnectPeer() {
 }
 
 /**
- * Explicitly disconnect a peer. Supervision does not auto-reconnect.
- * Optimistically flips status to `disconnected` with a "Disconnecting…"
- * detail so the transition is visible while the request is in flight.
+ * Explicitly stop a peer (disable supervision + disconnect). The peer
+ * settles to `stopped` — distinct from `disconnected`, which implies
+ * supervision is still trying to reconnect. Optimistically flips status
+ * to `disconnecting` so the transition is visible while the request is
+ * in flight.
  */
-export function useDisconnectPeer() {
+export function useStopPeer() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => disconnectPeer(id),
+    mutationFn: (id: string) => stopPeer(id),
     onMutate: (id) => ({
       prev: optimisticStatusPatch(qc, id, 'disconnecting'),
       id,
@@ -179,7 +182,7 @@ export function useDisconnectPeer() {
 }
 
 /**
- * Restart a peer by disconnecting then reconnecting. The transient state
+ * Restart a peer by stopping then starting. The transient state
  * is a single `restarting` status rather than the two-phase
  * `disconnecting` → `connecting` sequence you'd see from calling the
  * individual actions — the user asked for one, simpler transition.
@@ -188,8 +191,8 @@ export function useRestartPeer() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (id: string) => {
-      await disconnectPeer(id);
-      return connectPeer(id);
+      await stopPeer(id);
+      return startPeer(id);
     },
     onMutate: (id) => ({
       prev: optimisticStatusPatch(qc, id, 'restarting'),

--- a/web/src/api/resources/usePeerStatusToasts.ts
+++ b/web/src/api/resources/usePeerStatusToasts.ts
@@ -14,7 +14,7 @@ import { peerKeys, type Peer, type PeerStatus } from './peers';
  * Transient states (`connecting`, `disconnecting`, `restarting`) are
  * suppressed: they're already visible in the row badge and doubling up
  * would produce three toasts for a single restart. We only toast on
- * settled outcomes (`connected`, `disconnected`, `error`).
+ * settled outcomes (`connected`, `disconnected`, `stopped`, `error`).
  */
 export function usePeerStatusToasts() {
   const qc = useQueryClient();

--- a/web/src/api/schema.d.ts
+++ b/web/src/api/schema.d.ts
@@ -129,7 +129,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/peers/{id}/connect": {
+    "/peers/{id}/start": {
         parameters: {
             query?: never;
             header?: never;
@@ -142,20 +142,23 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Initiate a connection to this peer
-         * @description Triggers a CER/CEA exchange and moves the peer towards `connected`.
-         *     Returns the updated `Peer` immediately — the status may still be
-         *     `connecting` when the response is returned; clients should react
-         *     to subsequent `peer.updated` SSE events for the final outcome.
+         * Start this peer (enable supervision + connect)
+         * @description Enables the supervision loop for this peer and triggers a CER/CEA
+         *     exchange. Moves the peer from `stopped` through `connecting` to
+         *     `connected` (or `error` / `disconnected` with ongoing retries if
+         *     the handshake fails). Returns the updated `Peer` immediately —
+         *     the status may still be `connecting` when the response is
+         *     returned; clients should react to subsequent `peer.updated` SSE
+         *     events for the final outcome.
          */
-        post: operations["connectPeer"];
+        post: operations["startPeer"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/peers/{id}/disconnect": {
+    "/peers/{id}/stop": {
         parameters: {
             query?: never;
             header?: never;
@@ -168,13 +171,15 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Disconnect this peer
-         * @description Closes the Diameter transport. If `autoConnect` is true, the peer
-         *     will **not** be automatically reconnected — supervision only fires
-         *     at server startup. Use `POST /peers/{id}/connect` to reopen the
-         *     link explicitly.
+         * Stop this peer (disable supervision + disconnect)
+         * @description Administratively stops this peer: disables the supervision loop
+         *     and closes the Diameter transport. The peer transitions to
+         *     `stopped` and will not retry. This is distinct from the
+         *     transport-level `disconnected` state (where supervision is still
+         *     active and will redial on its own). Use `POST /peers/{id}/start`
+         *     to resume.
          */
-        post: operations["disconnectPeer"];
+        post: operations["stopPeer"];
         delete?: never;
         options?: never;
         head?: never;
@@ -414,8 +419,29 @@ export interface components {
             /** @description Number of executions currently in progress */
             activeRuns: number;
         };
-        /** @enum {string} */
-        PeerStatus: "connected" | "connecting" | "disconnected" | "disconnecting" | "restarting" | "error";
+        /**
+         * @description Current runtime state of a peer.
+         *
+         *     - `stopped`       — Administratively down. Supervision is off; no
+         *                         reconnect attempts will be made. This is the
+         *                         default state for a freshly created peer.
+         *     - `disconnected`  — Supervision is on but the transport is down.
+         *                         The server will redial automatically.
+         *     - `connecting`    — CER/CEA exchange in progress.
+         *     - `connected`     — Session established.
+         *     - `disconnecting` — Graceful teardown in progress (admin-initiated).
+         *     - `restarting`    — Admin-initiated stop followed by start so a
+         *                         config change can take effect.
+         *     - `error`         — Supervision is on but the peer is in a
+         *                         persistent failure state (exponential backoff).
+         *
+         *     The distinction between `stopped` and `disconnected` is
+         *     deliberate: the former means "admin does not want this up"; the
+         *     latter means "admin wants this up but the transport is
+         *     currently down".
+         * @enum {string}
+         */
+        PeerStatus: "stopped" | "disconnected" | "connecting" | "connected" | "disconnecting" | "restarting" | "error";
         /**
          * @description Transport protocol used for the Diameter connection.
          * @enum {string}
@@ -451,10 +477,15 @@ export interface components {
              */
             watchdogIntervalSeconds: number;
             /**
-             * @description If true, the server attempts to connect this peer at server
-             *     startup. Does **not** trigger a connection when the peer is
-             *     created or updated mid-run — those require an explicit
-             *     `POST /peers/{id}/connect`.
+             * @description Pure server-boot flag. When the server starts, peers with
+             *     `autoConnect: true` are automatically started (equivalent to
+             *     `POST /peers/{id}/start`); peers with `autoConnect: false`
+             *     remain `stopped` until the operator starts them.
+             *
+             *     This flag has **no bearing on current status**. A peer can
+             *     be `autoConnect: true` and `stopped` (the operator stopped
+             *     it after boot), or `autoConnect: false` and `connected`
+             *     (started manually during this run).
              * @default true
              */
             autoConnect: boolean;
@@ -890,7 +921,7 @@ export interface operations {
             default: components["responses"]["Problem"];
         };
     };
-    connectPeer: {
+    startPeer: {
         parameters: {
             query?: never;
             header?: never;
@@ -902,7 +933,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Connection attempt started */
+            /** @description Peer started */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -915,7 +946,7 @@ export interface operations {
             default: components["responses"]["Problem"];
         };
     };
-    disconnectPeer: {
+    stopPeer: {
         parameters: {
             query?: never;
             header?: never;
@@ -927,7 +958,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Peer disconnected */
+            /** @description Peer stopped */
             200: {
                 headers: {
                     [name: string]: unknown;

--- a/web/src/components/peer/peerStatus.ts
+++ b/web/src/components/peer/peerStatus.ts
@@ -1,6 +1,11 @@
 import type { PeerStatus } from '../../api/resources/peers';
 
 export const STATUS_COLOR: Record<PeerStatus, string> = {
+  // Stopped = admin down, no supervision. A deeper gray than `disconnected`
+  // (which is supervised-but-currently-down) — the distinction matters for
+  // the operator: `stopped` peers will not self-heal, `disconnected` peers
+  // are already retrying.
+  stopped: 'var(--mantine-color-gray-7)',
   connected: 'var(--mantine-color-teal-6)',
   disconnected: 'var(--mantine-color-gray-5)',
   error: 'var(--mantine-color-red-6)',
@@ -10,6 +15,7 @@ export const STATUS_COLOR: Record<PeerStatus, string> = {
 };
 
 export const STATUS_LABEL: Record<PeerStatus, string> = {
+  stopped: 'Stopped',
   connected: 'Connected',
   disconnected: 'Disconnected',
   error: 'Error',

--- a/web/src/mocks/data/peers.ts
+++ b/web/src/mocks/data/peers.ts
@@ -1,6 +1,6 @@
 import type { Peer } from '../../api/resources/peers';
 
-/** 5 peers, 3 connected, 1 disconnected, 1 error — matches dashboard KPIs. */
+/** 5 peers: 3 connected, 1 stopped (admin down), 1 error — matches dashboard KPIs. */
 export const peerFixtures: Peer[] = [
   {
     id: 'peer-01',
@@ -25,8 +25,8 @@ export const peerFixtures: Peer[] = [
     transport: 'TCP',
     watchdogIntervalSeconds: 30,
     autoConnect: false,
-    status: 'disconnected',
-    statusDetail: 'Administratively disabled',
+    status: 'stopped',
+    statusDetail: 'Administratively stopped',
     lastChangeAt: '2026-04-20T17:10:00Z',
   },
   {

--- a/web/src/mocks/fakeApi/peersFakeApi.ts
+++ b/web/src/mocks/fakeApi/peersFakeApi.ts
@@ -78,7 +78,7 @@ function applyInput(base: Partial<Peer>, input: PeerInput): Peer {
     transport: input.transport,
     watchdogIntervalSeconds: input.watchdogIntervalSeconds,
     autoConnect: input.autoConnect,
-    status: base.status ?? 'disconnected',
+    status: base.status ?? 'stopped',
     statusDetail: base.statusDetail,
     lastChangeAt: new Date().toISOString(),
   };
@@ -126,7 +126,11 @@ mock
     }
 
     const id = `peer-${String(peers.length + 1).padStart(2, '0')}`;
-    const created = applyInput({ id, status: 'disconnected' }, input!);
+    // Newly created peers are always `stopped` (admin down). The
+    // post-create lifecycle toast is where the operator chooses whether
+    // to start it now. `autoConnect` is a pure server-boot flag and has
+    // no bearing on the status of a just-created peer at runtime.
+    const created = applyInput({ id, status: 'stopped' }, input!);
     peers.push(created);
     return [201, created];
   });
@@ -199,16 +203,17 @@ mock
     return [200, updated];
   });
 
-// Connect — move peer to `connected` (with a brief `connecting` stop). The
-// second SSE-style flip would normally come from the server's transport
-// supervisor; the mock just returns the settled state for simplicity.
+// Start — enables supervision and moves peer to `connected` (with a brief
+// `connecting` transient). The second SSE-style flip would normally come
+// from the server's transport supervisor; the mock just returns the
+// settled state for simplicity.
 mock
-  .onPost(/\/peers\/[^/]+\/connect$/)
+  .onPost(/\/peers\/[^/]+\/start$/)
   // Held long enough that the `connecting` transient is visibly on screen
   // — a few hundred ms flickers past too fast to read.
   .withDelayInMs(10_000)
   .reply((config) => {
-    const m = /\/peers\/([^/]+)\/connect$/.exec(config.url ?? '');
+    const m = /\/peers\/([^/]+)\/start$/.exec(config.url ?? '');
     const id = m ? decodeURIComponent(m[1]) : '';
     const peer = peers.find((p) => p.id === id);
     if (!peer) {
@@ -235,12 +240,13 @@ mock
     return [200, peer];
   });
 
-// Disconnect — explicit disconnect. Supervision does not auto-reconnect.
+// Stop — explicit admin stop. Disables supervision; peer will not
+// auto-reconnect and settles to `stopped` (not `disconnected`).
 mock
-  .onPost(/\/peers\/[^/]+\/disconnect$/)
+  .onPost(/\/peers\/[^/]+\/stop$/)
   .withDelayInMs(10_000)
   .reply((config) => {
-    const m = /\/peers\/([^/]+)\/disconnect$/.exec(config.url ?? '');
+    const m = /\/peers\/([^/]+)\/stop$/.exec(config.url ?? '');
     const id = m ? decodeURIComponent(m[1]) : '';
     const peer = peers.find((p) => p.id === id);
     if (!peer) {
@@ -254,8 +260,8 @@ mock
         },
       ];
     }
-    peer.status = 'disconnected';
-    peer.statusDetail = 'Administratively disconnected';
+    peer.status = 'stopped';
+    peer.statusDetail = 'Administratively stopped';
     peer.lastChangeAt = new Date().toISOString();
     return [200, peer];
   });

--- a/web/src/pages/peers/PeerForm.tsx
+++ b/web/src/pages/peers/PeerForm.tsx
@@ -249,11 +249,13 @@ export function PeerForm({
           <Group justify="space-between" align="flex-start" wrap="nowrap">
             <Stack gap={2}>
               <Text size="sm" fw={500}>
-                Auto-connect on startup
+                Auto-start on server boot
               </Text>
               <Text size="xs" c="dimmed">
-                Connect this peer automatically when the server starts. Does
-                not connect the peer now — use the Connect action for that.
+                Start this peer automatically when the server boots. Has no
+                effect on the current status — a peer with this flag on can
+                still be Stopped by the operator, and this setting won&apos;t
+                start it now. Use the Start action for that.
               </Text>
             </Stack>
             <Switch

--- a/web/src/pages/peers/PeersPage.tsx
+++ b/web/src/pages/peers/PeersPage.tsx
@@ -8,7 +8,6 @@ import {
   Group,
   Menu,
   Modal,
-  SegmentedControl,
   Select,
   Skeleton,
   Stack,
@@ -27,7 +26,7 @@ import {
   IconPlugConnectedX,
   IconSearch,
 } from '@tabler/icons-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { ApiError } from '../../api/errors';
 import type {
@@ -51,31 +50,18 @@ import { PeerForm } from './PeerForm';
 
 type StatusFilter = 'all' | PeerStatus;
 
-type PeerPrompt =
-  | { kind: 'created'; peer: Peer }
+/**
+ * Modal prompt state. Only the `created` kind still uses the modal —
+ * updates raise a non-blocking toast instead. Kept as a discriminated
+ * union so re-introducing other modal flows later is a one-variant
+ * change.
+ */
+type PeerPrompt = { kind: 'created'; peer: Peer };
+
+/** Richer variant used by the update toast — separate from modal state. */
+type UpdateToastInput =
   | { kind: 'updated-idle'; peer: Peer }
   | { kind: 'updated-live'; peer: Peer };
-
-/**
- * Dev toggle for the post-update UX. Kept here rather than in Settings
- * so you can A/B the two styles side-by-side while evaluating. Persists
- * in localStorage so a page reload doesn't reset the choice. Remove this
- * (and pin one style) once the winner is clear.
- */
-type UpdatePromptStyle = 'modal' | 'toast';
-const UPDATE_PROMPT_STYLE_KEY = 'peers:updatePromptStyle';
-
-function useUpdatePromptStyle(): [UpdatePromptStyle, (v: UpdatePromptStyle) => void] {
-  const [style, setStyle] = useState<UpdatePromptStyle>(() => {
-    if (typeof window === 'undefined') return 'modal';
-    const v = window.localStorage.getItem(UPDATE_PROMPT_STYLE_KEY);
-    return v === 'toast' ? 'toast' : 'modal';
-  });
-  useEffect(() => {
-    window.localStorage.setItem(UPDATE_PROMPT_STYLE_KEY, style);
-  }, [style]);
-  return [style, setStyle];
-}
 
 /** Post-mutation a peer is "live" if it's active or attempting/holding an error. */
 function isLivePeer(p: Peer): boolean {
@@ -135,8 +121,11 @@ export function PeersPage() {
   //                         connected. Connect now?" → Connect
   //   - updated-live     → "Peer 'x' was updated. Currently connected.
   //                         Restart?" → Disconnect + Connect
+  // Only the `created` variant uses this state now — the modal is the
+  // right fit for a "you've just created a new thing, want to start it?"
+  // decision point. The `updated-*` variants fire a non-blocking toast
+  // with inline Connect/Restart actions instead (see showUpdateToast).
   const [prompt, setPrompt] = useState<PeerPrompt | undefined>();
-  const [updateUx, setUpdateUx] = useUpdatePromptStyle();
   const connect = useConnectPeer();
   const restart = useRestartPeer();
 
@@ -203,25 +192,6 @@ export function PeersPage() {
           leftSectionWidth={60}
           styles={{ input: { paddingLeft: 60 } }}
         />
-      </Group>
-
-      {/* Dev affordance — remove once we pin one of the two update flows. */}
-      <Group gap="xs" align="center">
-        <Text size="xs" c="dimmed" tt="uppercase" fw={600} style={{ letterSpacing: 0.5 }}>
-          Update prompt
-        </Text>
-        <SegmentedControl
-          size="xs"
-          value={updateUx}
-          onChange={(v) => setUpdateUx(v as UpdatePromptStyle)}
-          data={[
-            { label: 'Modal', value: 'modal' },
-            { label: 'Toast', value: 'toast' },
-          ]}
-        />
-        <Text size="xs" c="dimmed">
-          (A/B the post-update UX — persists locally)
-        </Text>
       </Group>
 
       {peers.isError ? (
@@ -343,14 +313,15 @@ export function PeersPage() {
           setDrawer({ kind: 'closed' });
           setDeleteTarget(p);
         }}
-        onUpdated={(p) => {
-          const kind = isLivePeer(p) ? 'updated-live' : 'updated-idle';
-          if (updateUx === 'modal') {
-            setPrompt({ kind, peer: p });
-          } else {
-            showUpdateToast({ kind, peer: p }, { connect, restart });
-          }
-        }}
+        onUpdated={(p) =>
+          showUpdateToast(
+            {
+              kind: isLivePeer(p) ? 'updated-live' : 'updated-idle',
+              peer: p,
+            },
+            { connect, restart },
+          )
+        }
       />
       <DeletePeerModal
         peer={deleteTarget}
@@ -595,11 +566,10 @@ function EditPeerForm({
   const handleSubmit = async (values: PeerInput) => {
     try {
       const next = await updatePeer.mutateAsync(values);
-      notifications.show({
-        color: 'teal',
-        title: 'Peer updated',
-        message: `${next.name} has been saved.`,
-      });
+      // No separate "saved" toast — the update action-toast raised by
+      // onUpdated already leads with "Peer 'x' updated", so firing a
+      // success toast here would just stack two notifications for the
+      // same event.
       onClose();
       setTimeout(() => onUpdated(next), 0);
       return next;
@@ -708,7 +678,6 @@ function PeerLifecyclePrompt({
   onClose: () => void;
 }) {
   const connect = useConnectPeer();
-  const restart = useRestartPeer();
 
   // Close the dialog the moment the user confirms, then let the mutation
   // settle in the background. The optimistic status patch already gives
@@ -716,22 +685,15 @@ function PeerLifecyclePrompt({
   // while the transport handshakes blocks the user for no reason.
   const handleConfirm = () => {
     if (!prompt) return;
-    const { peer, kind } = prompt;
-    const isRestart = kind === 'updated-live';
     onClose();
-
-    const promise = isRestart
-      ? restart.mutateAsync(peer.id)
-      : connect.mutateAsync(peer.id);
-
     // Success toast is handled globally by `usePeerStatusToasts`, which
     // fires on any status transition. We only need to surface thrown
     // errors here — a rollback leaves the cache unchanged, so no global
     // toast would fire for a failed request.
-    promise.catch((err: unknown) => {
+    connect.mutateAsync(prompt.peer.id).catch((err: unknown) => {
       notifications.show({
         color: 'red',
-        title: isRestart ? 'Restart failed' : 'Connect failed',
+        title: 'Connect failed',
         message: err instanceof Error ? err.message : 'Unexpected error',
       });
     });
@@ -768,44 +730,12 @@ function promptCopy(p: PeerPrompt): {
   confirmLabel: string;
 } {
   const name = <strong>&apos;{p.peer.name}&apos;</strong>;
-  switch (p.kind) {
-    case 'created':
-      return {
-        title: 'Connect peer now?',
-        body: (
-          <>
-            A new peer {name} was created. Would you like to connect it now?
-          </>
-        ),
-        cancelLabel: 'Not now',
-        confirmLabel: 'Connect',
-      };
-    case 'updated-idle':
-      return {
-        title: 'Connect peer now?',
-        body: (
-          <>
-            Peer {name} was updated but is not currently{' '}
-            <strong>connected</strong>. Would you like to connect it now?
-          </>
-        ),
-        cancelLabel: 'Not now',
-        confirmLabel: 'Connect',
-      };
-    case 'updated-live':
-      return {
-        title: 'Restart peer?',
-        body: (
-          <>
-            Peer {name} was updated. The peer is currently{' '}
-            <strong>connected</strong>. Would you like to restart it so that
-            the changes can take effect?
-          </>
-        ),
-        cancelLabel: 'Later',
-        confirmLabel: 'Restart',
-      };
-  }
+  return {
+    title: 'Connect peer now?',
+    body: <>A new peer {name} was created. Would you like to connect it now?</>,
+    cancelLabel: 'Not now',
+    confirmLabel: 'Connect',
+  };
 }
 
 /**
@@ -817,7 +747,7 @@ function promptCopy(p: PeerPrompt): {
  * bigger decision point and a transient toast is too easy to miss.
  */
 function showUpdateToast(
-  p: Extract<PeerPrompt, { kind: `updated-${string}` }>,
+  p: UpdateToastInput,
   mutations: {
     connect: ReturnType<typeof useConnectPeer>;
     restart: ReturnType<typeof useRestartPeer>;

--- a/web/src/pages/peers/PeersPage.tsx
+++ b/web/src/pages/peers/PeersPage.tsx
@@ -22,8 +22,8 @@ import {
   IconDots,
   IconPencil,
   IconPlus,
-  IconPlugConnected,
-  IconPlugConnectedX,
+  IconPlayerPlay,
+  IconPlayerStop,
   IconSearch,
 } from '@tabler/icons-react';
 import { useMemo, useState } from 'react';
@@ -36,14 +36,14 @@ import type {
   PeerTestResult,
 } from '../../api/resources/peers';
 import {
-  useConnectPeer,
   useCreatePeer,
   useDeletePeer,
   usePeers,
   useRestartPeer,
+  useStartPeer,
+  useStopPeer,
   useTestPeerConfig,
   useUpdatePeer,
-  useDisconnectPeer,
 } from '../../api/resources/peers';
 import { PeerStatusLabel } from '../../components/peer/PeerStatusLabel';
 import { PeerForm } from './PeerForm';
@@ -52,8 +52,8 @@ type StatusFilter = 'all' | PeerStatus;
 
 /**
  * Input to the post-mutation lifecycle toast. Three variants:
- *   - `created`       — brand-new peer; offer Connect.
- *   - `updated-idle`  — edited peer currently disconnected; offer Connect.
+ *   - `created`       — brand-new peer (always `stopped`); offer Start.
+ *   - `updated-idle`  — edited peer not currently running; offer Start.
  *   - `updated-live`  — edited peer currently live; offer Restart so the
  *                       new config takes effect.
  * All three use the same non-blocking toast — no modals.
@@ -63,7 +63,11 @@ type LifecycleToastInput =
   | { kind: 'updated-idle'; peer: Peer }
   | { kind: 'updated-live'; peer: Peer };
 
-/** Post-mutation a peer is "live" if it's active or attempting/holding an error. */
+/**
+ * Post-mutation a peer is "live" if supervision is engaged — either it's
+ * connected, in flight, or retrying. A `stopped` or `disconnected` peer
+ * is not live and the update toast should offer Start instead of Restart.
+ */
 function isLivePeer(p: Peer): boolean {
   return (
     p.status === 'connected' ||
@@ -105,6 +109,7 @@ const STATUS_FILTER_OPTIONS: { value: StatusFilter; label: string }[] = [
   { value: 'connecting', label: 'Connecting' },
   { value: 'disconnecting', label: 'Disconnecting' },
   { value: 'disconnected', label: 'Disconnected' },
+  { value: 'stopped', label: 'Stopped' },
   { value: 'error', label: 'Error' },
 ];
 
@@ -131,7 +136,7 @@ export function PeersPage() {
   // All three post-mutation flows (created / updated-idle / updated-live)
   // surface as a non-blocking toast with inline Connect/Restart actions.
   // See `showLifecycleToast`.
-  const connect = useConnectPeer();
+  const start = useStartPeer();
   const restart = useRestartPeer();
 
   const filtered = useMemo(() => {
@@ -310,7 +315,7 @@ export function PeersPage() {
         open={drawer.kind === 'create'}
         onClose={() => setDrawer({ kind: 'closed' })}
         onCreated={(p) =>
-          showLifecycleToast({ kind: 'created', peer: p }, { connect, restart })
+          showLifecycleToast({ kind: 'created', peer: p }, { start, restart })
         }
       />
       <EditPeerDrawer
@@ -326,7 +331,7 @@ export function PeersPage() {
               kind: isLivePeer(p) ? 'updated-live' : 'updated-idle',
               peer: p,
             },
-            { connect, restart },
+            { start, restart },
           )
         }
       />
@@ -339,7 +344,7 @@ export function PeersPage() {
 }
 
 /**
- * Kebab menu on each row — Connect/Disconnect + Edit only. Destructive
+ * Kebab menu on each row — Start/Stop + Edit only. Destructive
  * actions (Delete) deliberately live inside the Edit drawer so the full
  * peer identity is visible at the moment of confirmation — reduces the
  * risk of deleting the wrong row from a dense table. This is the
@@ -352,13 +357,14 @@ function RowMenu({
   peer: Peer;
   onEdit: () => void;
 }) {
-  const connect = useConnectPeer();
-  const disconnect = useDisconnectPeer();
-  // Only `disconnected` offers Connect. Every other state — connected,
-  // connecting, disconnecting, restarting, error — offers Disconnect so
-  // the user has a way to stop the session (including a peer that's
-  // stuck in `error` retrying supervision).
-  const showDisconnect = peer.status !== 'disconnected';
+  const start = useStartPeer();
+  const stop = useStopPeer();
+  // Only `stopped` offers Start. Every other state — connected,
+  // connecting, disconnected, disconnecting, restarting, error — offers
+  // Stop so the user has a way to halt supervision (including a peer
+  // stuck in `error` retrying, or a `disconnected` peer that's still
+  // being redialed by supervision).
+  const showStop = peer.status !== 'stopped';
   // Transient states are mid-transition; kicking off a second action
   // during one would race the optimistic patch. Disable the menu item
   // until the peer settles.
@@ -371,25 +377,25 @@ function RowMenu({
   // watches the list cache and fires on every settled status change, so
   // we only need to surface thrown errors (optimistic rollback puts the
   // cache back to the previous state, which produces no transition).
-  const handleConnect = async () => {
+  const handleStart = async () => {
     try {
-      await connect.mutateAsync(peer.id);
+      await start.mutateAsync(peer.id);
     } catch (err) {
       notifications.show({
         color: 'red',
-        title: 'Connect failed',
+        title: 'Start failed',
         message: err instanceof Error ? err.message : 'Unexpected error',
       });
     }
   };
 
-  const handleDisconnect = async () => {
+  const handleStop = async () => {
     try {
-      await disconnect.mutateAsync(peer.id);
+      await stop.mutateAsync(peer.id);
     } catch (err) {
       notifications.show({
         color: 'red',
-        title: 'Disconnect failed',
+        title: 'Stop failed',
         message: err instanceof Error ? err.message : 'Unexpected error',
       });
     }
@@ -407,21 +413,21 @@ function RowMenu({
         </ActionIcon>
       </Menu.Target>
       <Menu.Dropdown>
-        {showDisconnect ? (
+        {showStop ? (
           <Menu.Item
-            leftSection={<IconPlugConnectedX size={14} />}
-            onClick={handleDisconnect}
-            disabled={isTransient || disconnect.isPending}
+            leftSection={<IconPlayerStop size={14} />}
+            onClick={handleStop}
+            disabled={isTransient || stop.isPending}
           >
-            Disconnect
+            Stop
           </Menu.Item>
         ) : (
           <Menu.Item
-            leftSection={<IconPlugConnected size={14} />}
-            onClick={handleConnect}
-            disabled={isTransient || connect.isPending}
+            leftSection={<IconPlayerPlay size={14} />}
+            onClick={handleStart}
+            disabled={isTransient || start.isPending}
           >
-            Connect
+            Start
           </Menu.Item>
         )}
         <Menu.Item leftSection={<IconPencil size={14} />} onClick={onEdit}>
@@ -667,16 +673,17 @@ function DeletePeerModal({
 }
 
 /**
- * Unified post-mutation toast with inline Connect/Restart action. Used
- * for all three flows (create, update-idle, update-live). Non-blocking:
- * the user can keep working and the reminder sits in the corner until
- * they act, dismiss, or it auto-closes after 10 s. autoConnect is
- * intentionally not mentioned — it governs server-startup only.
+ * Unified post-mutation toast with inline Start/Restart action. Used for
+ * all three flows (create, update-idle, update-live). Non-blocking: the
+ * user can keep working and the reminder sits in the corner until they
+ * act, dismiss, or it auto-closes after 10 s. `autoConnect` is
+ * intentionally not mentioned — it governs server-startup only and has
+ * no bearing on the current peer status.
  */
 function showLifecycleToast(
   p: LifecycleToastInput,
   mutations: {
-    connect: ReturnType<typeof useConnectPeer>;
+    start: ReturnType<typeof useStartPeer>;
     restart: ReturnType<typeof useRestartPeer>;
   },
 ) {
@@ -687,11 +694,11 @@ function showLifecycleToast(
     notifications.hide(id);
     const promise = isRestart
       ? mutations.restart.mutateAsync(p.peer.id)
-      : mutations.connect.mutateAsync(p.peer.id);
+      : mutations.start.mutateAsync(p.peer.id);
     promise.catch((err: unknown) => {
       notifications.show({
         color: 'red',
-        title: isRestart ? 'Restart failed' : 'Connect failed',
+        title: isRestart ? 'Restart failed' : 'Start failed',
         message: err instanceof Error ? err.message : 'Unexpected error',
       });
     });
@@ -704,7 +711,7 @@ function showLifecycleToast(
 
   const body =
     p.kind === 'created' ? (
-      <>Would you like to connect it now?</>
+      <>Would you like to <strong>start</strong> it now?</>
     ) : isRestart ? (
       <>
         Currently <strong>connected</strong>. Restart to apply the new
@@ -712,8 +719,8 @@ function showLifecycleToast(
       </>
     ) : (
       <>
-        Not currently <strong>connected</strong>. Connect now to start the
-        peer.
+        Not currently <strong>running</strong>. Start the peer now to apply
+        the new configuration.
       </>
     );
 
@@ -734,7 +741,7 @@ function showLifecycleToast(
         </Text>
         <Group gap="xs">
           <Button size="xs" variant="light" onClick={run}>
-            {isRestart ? 'Restart now' : 'Connect now'}
+            {isRestart ? 'Restart now' : 'Start now'}
           </Button>
           <Button
             size="xs"

--- a/web/src/pages/peers/PeersPage.tsx
+++ b/web/src/pages/peers/PeersPage.tsx
@@ -51,15 +51,15 @@ import { PeerForm } from './PeerForm';
 type StatusFilter = 'all' | PeerStatus;
 
 /**
- * Modal prompt state. Only the `created` kind still uses the modal —
- * updates raise a non-blocking toast instead. Kept as a discriminated
- * union so re-introducing other modal flows later is a one-variant
- * change.
+ * Input to the post-mutation lifecycle toast. Three variants:
+ *   - `created`       — brand-new peer; offer Connect.
+ *   - `updated-idle`  — edited peer currently disconnected; offer Connect.
+ *   - `updated-live`  — edited peer currently live; offer Restart so the
+ *                       new config takes effect.
+ * All three use the same non-blocking toast — no modals.
  */
-type PeerPrompt = { kind: 'created'; peer: Peer };
-
-/** Richer variant used by the update toast — separate from modal state. */
-type UpdateToastInput =
+type LifecycleToastInput =
+  | { kind: 'created'; peer: Peer }
   | { kind: 'updated-idle'; peer: Peer }
   | { kind: 'updated-live'; peer: Peer };
 
@@ -78,6 +78,13 @@ function isLivePeer(p: Peer): boolean {
  * Drawer body has its own `overflow: auto`, which fights the form's own
  * scroll region and pushes the footer off-screen when the body grows.
  */
+/**
+ * Mantine's default Drawer transition is 150 ms; we wait slightly longer
+ * before firing any follow-up toast/modal so the notification doesn't
+ * land behind the still-closing drawer in the top-right corner.
+ */
+const DRAWER_CLOSE_TRANSITION_MS = 250;
+
 const DRAWER_STYLES = {
   content: {
     display: 'flex',
@@ -121,11 +128,9 @@ export function PeersPage() {
   //                         connected. Connect now?" → Connect
   //   - updated-live     → "Peer 'x' was updated. Currently connected.
   //                         Restart?" → Disconnect + Connect
-  // Only the `created` variant uses this state now — the modal is the
-  // right fit for a "you've just created a new thing, want to start it?"
-  // decision point. The `updated-*` variants fire a non-blocking toast
-  // with inline Connect/Restart actions instead (see showUpdateToast).
-  const [prompt, setPrompt] = useState<PeerPrompt | undefined>();
+  // All three post-mutation flows (created / updated-idle / updated-live)
+  // surface as a non-blocking toast with inline Connect/Restart actions.
+  // See `showLifecycleToast`.
   const connect = useConnectPeer();
   const restart = useRestartPeer();
 
@@ -304,7 +309,9 @@ export function PeersPage() {
       <CreatePeerDrawer
         open={drawer.kind === 'create'}
         onClose={() => setDrawer({ kind: 'closed' })}
-        onCreated={(p) => setPrompt({ kind: 'created', peer: p })}
+        onCreated={(p) =>
+          showLifecycleToast({ kind: 'created', peer: p }, { connect, restart })
+        }
       />
       <EditPeerDrawer
         peer={drawer.kind === 'edit' ? drawer.peer : undefined}
@@ -314,7 +321,7 @@ export function PeersPage() {
           setDeleteTarget(p);
         }}
         onUpdated={(p) =>
-          showUpdateToast(
+          showLifecycleToast(
             {
               kind: isLivePeer(p) ? 'updated-live' : 'updated-idle',
               peer: p,
@@ -326,10 +333,6 @@ export function PeersPage() {
       <DeletePeerModal
         peer={deleteTarget}
         onClose={() => setDeleteTarget(undefined)}
-      />
-      <PeerLifecyclePrompt
-        prompt={prompt}
-        onClose={() => setPrompt(undefined)}
       />
     </Stack>
   );
@@ -478,7 +481,12 @@ function CreatePeerDrawer({
       onClose();
       // Defer so the drawer close transition runs before the modal opens —
       // avoids the modal overlay stacking under the drawer's fade-out.
-      setTimeout(() => onCreated(peer), 0);
+      // Wait for the Drawer's close transition to finish before firing
+      // the follow-up prompt — otherwise the Drawer still briefly covers
+      // the top-right corner where the toast/modal lands, and the
+      // notification flashes *behind* it. Mantine's default Drawer
+      // transition is 150 ms; 250 ms gives a safe margin.
+      setTimeout(() => onCreated(peer), DRAWER_CLOSE_TRANSITION_MS);
       return peer;
     } catch (err) {
       if (err instanceof ApiError && err.status === 422) throw err;
@@ -571,7 +579,7 @@ function EditPeerForm({
       // success toast here would just stack two notifications for the
       // same event.
       onClose();
-      setTimeout(() => onUpdated(next), 0);
+      setTimeout(() => onUpdated(next), DRAWER_CLOSE_TRANSITION_MS);
       return next;
     } catch (err) {
       if (err instanceof ApiError && err.status === 422) throw err;
@@ -659,102 +667,21 @@ function DeletePeerModal({
 }
 
 /**
- * Unified post-mutation lifecycle prompt. Three variants:
- *
- *   - `created`       — new peer; offer immediate connect.
- *   - `updated-idle`  — edited peer that is not live; offer connect.
- *   - `updated-live`  — edited peer that is live; offer restart so the
- *                       new config takes effect on the running session.
- *
- * autoConnect is intentionally **not** mentioned in any variant — it
- * governs server-startup behaviour only (documented in the form helper
- * text) and has no bearing on the decision here.
+ * Unified post-mutation toast with inline Connect/Restart action. Used
+ * for all three flows (create, update-idle, update-live). Non-blocking:
+ * the user can keep working and the reminder sits in the corner until
+ * they act, dismiss, or it auto-closes after 10 s. autoConnect is
+ * intentionally not mentioned — it governs server-startup only.
  */
-function PeerLifecyclePrompt({
-  prompt,
-  onClose,
-}: {
-  prompt: PeerPrompt | undefined;
-  onClose: () => void;
-}) {
-  const connect = useConnectPeer();
-
-  // Close the dialog the moment the user confirms, then let the mutation
-  // settle in the background. The optimistic status patch already gives
-  // live feedback in the row; holding the modal open for 10+ seconds
-  // while the transport handshakes blocks the user for no reason.
-  const handleConfirm = () => {
-    if (!prompt) return;
-    onClose();
-    // Success toast is handled globally by `usePeerStatusToasts`, which
-    // fires on any status transition. We only need to surface thrown
-    // errors here — a rollback leaves the cache unchanged, so no global
-    // toast would fire for a failed request.
-    connect.mutateAsync(prompt.peer.id).catch((err: unknown) => {
-      notifications.show({
-        color: 'red',
-        title: 'Connect failed',
-        message: err instanceof Error ? err.message : 'Unexpected error',
-      });
-    });
-  };
-
-  const copy = prompt ? promptCopy(prompt) : undefined;
-
-  return (
-    <Modal
-      opened={Boolean(prompt)}
-      onClose={onClose}
-      title={copy?.title ?? ''}
-      centered
-    >
-      <Stack gap="md">
-        <Text size="sm">{copy?.body}</Text>
-        <Group justify="flex-end">
-          <Button variant="subtle" onClick={onClose}>
-            {copy?.cancelLabel ?? 'Cancel'}
-          </Button>
-          <Button onClick={handleConfirm}>
-            {copy?.confirmLabel ?? 'Confirm'}
-          </Button>
-        </Group>
-      </Stack>
-    </Modal>
-  );
-}
-
-function promptCopy(p: PeerPrompt): {
-  title: string;
-  body: React.ReactNode;
-  cancelLabel: string;
-  confirmLabel: string;
-} {
-  const name = <strong>&apos;{p.peer.name}&apos;</strong>;
-  return {
-    title: 'Connect peer now?',
-    body: <>A new peer {name} was created. Would you like to connect it now?</>,
-    cancelLabel: 'Not now',
-    confirmLabel: 'Connect',
-  };
-}
-
-/**
- * Non-blocking alternative to `PeerLifecyclePrompt` for the update path:
- * a toast with an inline action button. Lives in the same global toast
- * channel as status changes, so after editing you can keep working and
- * the reminder sits unobtrusively in the corner until you act or
- * dismiss. The `created` path still uses the modal — a new peer is a
- * bigger decision point and a transient toast is too easy to miss.
- */
-function showUpdateToast(
-  p: UpdateToastInput,
+function showLifecycleToast(
+  p: LifecycleToastInput,
   mutations: {
     connect: ReturnType<typeof useConnectPeer>;
     restart: ReturnType<typeof useRestartPeer>;
   },
 ) {
   const isRestart = p.kind === 'updated-live';
-  const id = `peer-update-${p.peer.id}-${Date.now()}`;
+  const id = `peer-lifecycle-${p.peer.id}-${Date.now()}`;
 
   const run = () => {
     notifications.hide(id);
@@ -770,6 +697,26 @@ function showUpdateToast(
     });
   };
 
+  const title =
+    p.kind === 'created'
+      ? `Peer '${p.peer.name}' created`
+      : `Peer '${p.peer.name}' updated`;
+
+  const body =
+    p.kind === 'created' ? (
+      <>Would you like to connect it now?</>
+    ) : isRestart ? (
+      <>
+        Currently <strong>connected</strong>. Restart to apply the new
+        configuration.
+      </>
+    ) : (
+      <>
+        Not currently <strong>connected</strong>. Connect now to start the
+        peer.
+      </>
+    );
+
   notifications.show({
     id,
     withCloseButton: true,
@@ -777,23 +724,13 @@ function showUpdateToast(
     color: isRestart ? 'yellow' : 'blue',
     title: (
       <Text size="sm" fw={600}>
-        Peer &apos;{p.peer.name}&apos; updated
+        {title}
       </Text>
     ),
     message: (
       <Stack gap={8} mt={4}>
         <Text size="sm" c="dimmed">
-          {isRestart ? (
-            <>
-              Currently <strong>connected</strong>. Restart to apply the new
-              configuration.
-            </>
-          ) : (
-            <>
-              Not currently <strong>connected</strong>. Connect now to start
-              the peer.
-            </>
-          )}
+          {body}
         </Text>
         <Group gap="xs">
           <Button size="xs" variant="light" onClick={run}>

--- a/web/src/pages/peers/PeersPage.tsx
+++ b/web/src/pages/peers/PeersPage.tsx
@@ -8,6 +8,7 @@ import {
   Group,
   Menu,
   Modal,
+  SegmentedControl,
   Select,
   Skeleton,
   Stack,
@@ -26,7 +27,7 @@ import {
   IconPlugConnectedX,
   IconSearch,
 } from '@tabler/icons-react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { ApiError } from '../../api/errors';
 import type {
@@ -54,6 +55,27 @@ type PeerPrompt =
   | { kind: 'created'; peer: Peer }
   | { kind: 'updated-idle'; peer: Peer }
   | { kind: 'updated-live'; peer: Peer };
+
+/**
+ * Dev toggle for the post-update UX. Kept here rather than in Settings
+ * so you can A/B the two styles side-by-side while evaluating. Persists
+ * in localStorage so a page reload doesn't reset the choice. Remove this
+ * (and pin one style) once the winner is clear.
+ */
+type UpdatePromptStyle = 'modal' | 'toast';
+const UPDATE_PROMPT_STYLE_KEY = 'peers:updatePromptStyle';
+
+function useUpdatePromptStyle(): [UpdatePromptStyle, (v: UpdatePromptStyle) => void] {
+  const [style, setStyle] = useState<UpdatePromptStyle>(() => {
+    if (typeof window === 'undefined') return 'modal';
+    const v = window.localStorage.getItem(UPDATE_PROMPT_STYLE_KEY);
+    return v === 'toast' ? 'toast' : 'modal';
+  });
+  useEffect(() => {
+    window.localStorage.setItem(UPDATE_PROMPT_STYLE_KEY, style);
+  }, [style]);
+  return [style, setStyle];
+}
 
 /** Post-mutation a peer is "live" if it's active or attempting/holding an error. */
 function isLivePeer(p: Peer): boolean {
@@ -114,6 +136,9 @@ export function PeersPage() {
   //   - updated-live     → "Peer 'x' was updated. Currently connected.
   //                         Restart?" → Disconnect + Connect
   const [prompt, setPrompt] = useState<PeerPrompt | undefined>();
+  const [updateUx, setUpdateUx] = useUpdatePromptStyle();
+  const connect = useConnectPeer();
+  const restart = useRestartPeer();
 
   const filtered = useMemo(() => {
     if (!peers.data) return [];
@@ -178,6 +203,25 @@ export function PeersPage() {
           leftSectionWidth={60}
           styles={{ input: { paddingLeft: 60 } }}
         />
+      </Group>
+
+      {/* Dev affordance — remove once we pin one of the two update flows. */}
+      <Group gap="xs" align="center">
+        <Text size="xs" c="dimmed" tt="uppercase" fw={600} style={{ letterSpacing: 0.5 }}>
+          Update prompt
+        </Text>
+        <SegmentedControl
+          size="xs"
+          value={updateUx}
+          onChange={(v) => setUpdateUx(v as UpdatePromptStyle)}
+          data={[
+            { label: 'Modal', value: 'modal' },
+            { label: 'Toast', value: 'toast' },
+          ]}
+        />
+        <Text size="xs" c="dimmed">
+          (A/B the post-update UX — persists locally)
+        </Text>
       </Group>
 
       {peers.isError ? (
@@ -299,12 +343,14 @@ export function PeersPage() {
           setDrawer({ kind: 'closed' });
           setDeleteTarget(p);
         }}
-        onUpdated={(p) =>
-          setPrompt({
-            kind: isLivePeer(p) ? 'updated-live' : 'updated-idle',
-            peer: p,
-          })
-        }
+        onUpdated={(p) => {
+          const kind = isLivePeer(p) ? 'updated-live' : 'updated-idle';
+          if (updateUx === 'modal') {
+            setPrompt({ kind, peer: p });
+          } else {
+            showUpdateToast({ kind, peer: p }, { connect, restart });
+          }
+        }}
       />
       <DeletePeerModal
         peer={deleteTarget}
@@ -760,4 +806,79 @@ function promptCopy(p: PeerPrompt): {
         confirmLabel: 'Restart',
       };
   }
+}
+
+/**
+ * Non-blocking alternative to `PeerLifecyclePrompt` for the update path:
+ * a toast with an inline action button. Lives in the same global toast
+ * channel as status changes, so after editing you can keep working and
+ * the reminder sits unobtrusively in the corner until you act or
+ * dismiss. The `created` path still uses the modal — a new peer is a
+ * bigger decision point and a transient toast is too easy to miss.
+ */
+function showUpdateToast(
+  p: Extract<PeerPrompt, { kind: `updated-${string}` }>,
+  mutations: {
+    connect: ReturnType<typeof useConnectPeer>;
+    restart: ReturnType<typeof useRestartPeer>;
+  },
+) {
+  const isRestart = p.kind === 'updated-live';
+  const id = `peer-update-${p.peer.id}-${Date.now()}`;
+
+  const run = () => {
+    notifications.hide(id);
+    const promise = isRestart
+      ? mutations.restart.mutateAsync(p.peer.id)
+      : mutations.connect.mutateAsync(p.peer.id);
+    promise.catch((err: unknown) => {
+      notifications.show({
+        color: 'red',
+        title: isRestart ? 'Restart failed' : 'Connect failed',
+        message: err instanceof Error ? err.message : 'Unexpected error',
+      });
+    });
+  };
+
+  notifications.show({
+    id,
+    withCloseButton: true,
+    autoClose: 10_000,
+    color: isRestart ? 'yellow' : 'blue',
+    title: (
+      <Text size="sm" fw={600}>
+        Peer &apos;{p.peer.name}&apos; updated
+      </Text>
+    ),
+    message: (
+      <Stack gap={8} mt={4}>
+        <Text size="sm" c="dimmed">
+          {isRestart ? (
+            <>
+              Currently <strong>connected</strong>. Restart to apply the new
+              configuration.
+            </>
+          ) : (
+            <>
+              Not currently <strong>connected</strong>. Connect now to start
+              the peer.
+            </>
+          )}
+        </Text>
+        <Group gap="xs">
+          <Button size="xs" variant="light" onClick={run}>
+            {isRestart ? 'Restart now' : 'Connect now'}
+          </Button>
+          <Button
+            size="xs"
+            variant="subtle"
+            color="gray"
+            onClick={() => notifications.hide(id)}
+          >
+            Dismiss
+          </Button>
+        </Group>
+      </Stack>
+    ),
+  });
 }

--- a/web/src/pages/peers/PeersPage.tsx
+++ b/web/src/pages/peers/PeersPage.tsx
@@ -479,11 +479,10 @@ function CreatePeerDrawer({
   const handleSubmit = async (values: PeerInput) => {
     try {
       const peer = await createPeer.mutateAsync(values);
-      notifications.show({
-        color: 'teal',
-        title: 'Peer created',
-        message: `${peer.name} is ready.`,
-      });
+      // No separate "created" toast — the lifecycle toast raised by
+      // onCreated already leads with "Peer 'x' created", so firing a
+      // success toast here would just stack two notifications for the
+      // same event (same reasoning as the update flow).
       onClose();
       // Defer so the drawer close transition runs before the modal opens —
       // avoids the modal overlay stacking under the drawer's fade-out.


### PR DESCRIPTION
## Summary
- Adds optimistic Connecting/Disconnecting/Restarting transitions and single-toast lifecycle prompts (create / update-idle / update-live) with inline Start/Restart actions
- Introduces the `stopped` (admin down, no supervision) vs `disconnected` (supervised, transport down) distinction end-to-end — OpenAPI renames `/connect`→`/start`, `/disconnect`→`/stop`; `autoConnect` is reframed as a pure server-boot flag
- Global peer-status toasts fire on every settled status change regardless of which page is open; drawer/toast z-race fixed; various smaller fixes (kebab Start/Stop, error-state stoppability, duplicate-toast removal)

## Test plan
- [ ] Create a peer with empty fields — Create button stays disabled; Start now toast fires after save with no duplicate "created" toast
- [ ] Edit a `stopped`/`disconnected` peer — update toast offers Start; editing a `connected` peer offers Restart
- [ ] Kebab shows Start when `stopped`, Stop otherwise (incl. `error` and `disconnected`); disabled during `connecting`/`disconnecting`/`restarting`
- [ ] Global toasts fire for SSE-driven status changes from Dashboard page
- [ ] Host field defaults to `127.0.0.1`; 10.0.99.x simulates CER/CEA timeout
- [ ] `tsc --noEmit`, `npm run lint`, `npm run build` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)