### PR TITLE
feat(web): subscribers CRUD with TAC catalogue + IMEI generator

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -873,19 +873,15 @@ components:
         credentials (MSISDN + ICCID), an optional device binding
         (Manufacturer + Model, expressed server-side as a TAC prefix), and
         an optional IMEI (only meaningful when a device is bound).
-      required: [id, name, msisdn, iccid]
+      required: [id, msisdn, iccid]
       properties:
         id:
           type: string
-        name:
-          type: string
-          description: Human-readable label for this subscriber
-          examples: ['Alice Test']
         msisdn:
           type: string
           description: |
-            E.164-style MSISDN, digits only (no `+` prefix). Unique across
-            subscribers.
+            E.164-style MSISDN, digits only (no `+` prefix). The primary
+            identifier of a subscriber; unique across subscribers.
           pattern: '^[0-9]{8,15}$'
           examples: ['27821234567']
         iccid:
@@ -919,12 +915,8 @@ components:
       description: |
         Writable subset of `Subscriber`. Used for both create
         (POST /subscribers) and replace (PUT /subscribers/{id}).
-      required: [name, msisdn, iccid]
+      required: [msisdn, iccid]
       properties:
-        name:
-          type: string
-          minLength: 1
-          maxLength: 64
         msisdn:
           type: string
           pattern: '^[0-9]{8,15}$'

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -290,17 +290,128 @@ paths:
     get:
       tags: [Subscribers]
       operationId: listSubscribers
-      summary: List subscribers (paginated)
-      parameters:
-        - $ref: '#/components/parameters/LimitQuery'
-        - $ref: '#/components/parameters/OffsetQuery'
+      summary: List subscribers
+      description: |
+        Returns every configured subscriber. The testbench is expected to
+        hold at most a few thousand subscribers so the list is returned
+        unpaginated — the UI does client-side search/filter.
       responses:
         '200':
-          description: Paginated subscriber list
+          description: Subscriber list
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SubscriberPage'
+                type: array
+                items:
+                  $ref: '#/components/schemas/Subscriber'
+        default:
+          $ref: '#/components/responses/Problem'
+    post:
+      tags: [Subscribers]
+      operationId: createSubscriber
+      summary: Create a new subscriber
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubscriberInput'
+      responses:
+        '201':
+          description: Subscriber created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Subscriber'
+        '422':
+          $ref: '#/components/responses/ValidationProblem'
+        default:
+          $ref: '#/components/responses/Problem'
+
+  /subscribers/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdPath'
+    get:
+      tags: [Subscribers]
+      operationId: getSubscriber
+      summary: Get a single subscriber by id
+      responses:
+        '200':
+          description: Subscriber detail
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Subscriber'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/Problem'
+    put:
+      tags: [Subscribers]
+      operationId: updateSubscriber
+      summary: Replace a subscriber's configuration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubscriberInput'
+      responses:
+        '200':
+          description: Subscriber updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Subscriber'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationProblem'
+        default:
+          $ref: '#/components/responses/Problem'
+    delete:
+      tags: [Subscribers]
+      operationId: deleteSubscriber
+      summary: Delete a subscriber
+      responses:
+        '204':
+          description: Subscriber deleted
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/Problem'
+
+  /tac-catalog:
+    get:
+      tags: [Subscribers]
+      operationId: listTacCatalog
+      summary: Curated TAC (Type Allocation Code) catalogue
+      description: |
+        Returns the curated list of device manufacturer/model combinations
+        supported by this testbench, each with its 8-digit TAC prefix.
+        The catalogue covers roughly the last 10 years of popular handsets
+        across major OEMs — it is intentionally a small curated set rather
+        than the full GSMA TAC database.
+
+        The UI uses this to:
+        - populate cascading Manufacturer → Model selects on the
+          subscriber edit drawer
+        - derive the TAC prefix used when generating an IMEI
+        - display the canonical "Device" label on the subscribers list
+          (e.g. `iPhone 14 Pro` is reconstructed from the `tac` on a
+          `Subscriber` by looking it up here)
+
+        Returned items are immutable on the server side and may be cached
+        aggressively by clients (`ETag` / `Cache-Control: public`).
+      responses:
+        '200':
+          description: TAC catalogue
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TacEntry'
         default:
           $ref: '#/components/responses/Problem'
 
@@ -757,30 +868,107 @@ components:
 
     Subscriber:
       type: object
-      required: [id, msisdn]
+      description: |
+        A subscriber identity used by test scenarios. Carries the SIM
+        credentials (MSISDN + ICCID), an optional device binding
+        (Manufacturer + Model, expressed server-side as a TAC prefix), and
+        an optional IMEI (only meaningful when a device is bound).
+      required: [id, name, msisdn, iccid]
       properties:
         id:
           type: string
+        name:
+          type: string
+          description: Human-readable label for this subscriber
+          examples: ['Alice Test']
         msisdn:
           type: string
-          description: Subscriber MSISDN
-        imsi:
+          description: |
+            E.164-style MSISDN, digits only (no `+` prefix). Unique across
+            subscribers.
+          pattern: '^[0-9]{8,15}$'
+          examples: ['27821234567']
+        iccid:
           type: string
+          description: |
+            Integrated Circuit Card Identifier (SIM serial), 19 or 20
+            digits. Unique across subscribers.
+          pattern: '^[0-9]{19,20}$'
+          examples: ['89270100001234567890']
+        tac:
+          type: string
+          description: |
+            8-digit Type Allocation Code identifying the device
+            manufacturer + model. When present, the server recognises it
+            as one of the catalogue entries at `GET /tac-catalog` and
+            the UI looks up Manufacturer/Model labels from there.
+          pattern: '^[0-9]{8}$'
+          examples: ['35398506']
         imei:
           type: string
-        notes:
-          type: string
+          description: |
+            15-digit IMEI (TAC + 6 serial + Luhn check digit). Only
+            present when a device is bound (`tac` is set). Not unique —
+            the same physical device can legitimately be paired with
+            multiple test subscribers.
+          pattern: '^[0-9]{15}$'
+          examples: ['353985067894321']
 
-    SubscriberPage:
+    SubscriberInput:
       type: object
-      required: [items, page]
+      description: |
+        Writable subset of `Subscriber`. Used for both create
+        (POST /subscribers) and replace (PUT /subscribers/{id}).
+      required: [name, msisdn, iccid]
       properties:
-        items:
-          type: array
-          items:
-            $ref: '#/components/schemas/Subscriber'
-        page:
-          $ref: '#/components/schemas/PageMeta'
+        name:
+          type: string
+          minLength: 1
+          maxLength: 64
+        msisdn:
+          type: string
+          pattern: '^[0-9]{8,15}$'
+        iccid:
+          type: string
+          pattern: '^[0-9]{19,20}$'
+        tac:
+          type: string
+          description: |
+            Optional 8-digit TAC. When set, must match an entry in
+            `GET /tac-catalog` — the server will reject unknown TACs with
+            a 422.
+          pattern: '^[0-9]{8}$'
+        imei:
+          type: string
+          description: |
+            Optional 15-digit IMEI. Must be Luhn-valid and, when `tac`
+            is also set, must share the same 8-digit prefix as `tac`.
+            Rejected with 422 otherwise.
+          pattern: '^[0-9]{15}$'
+
+    TacEntry:
+      type: object
+      description: |
+        One entry in the curated TAC catalogue. Identifies a single
+        manufacturer/model combination by its 8-digit TAC prefix.
+      required: [tac, manufacturer, model]
+      properties:
+        tac:
+          type: string
+          description: 8-digit Type Allocation Code
+          pattern: '^[0-9]{8}$'
+          examples: ['35398506']
+        manufacturer:
+          type: string
+          examples: ['Apple']
+        model:
+          type: string
+          examples: ['iPhone 14 Pro']
+        year:
+          type: integer
+          description: Release year (informational)
+          minimum: 2000
+          maximum: 2099
 
     # ─────────────── Templates ───────────────
 

--- a/web/scripts/extract-tac-catalog.mjs
+++ b/web/scripts/extract-tac-catalog.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * Extract a curated TAC catalogue from the Osmocom TAC database.
+ *
+ * Source: http://tacdb.osmocom.org/export/tacdb.json
+ * Licence: CC-BY-SA v3.0 (© Harald Welte 2016) — attribution carried in
+ * the header of the output file.
+ *
+ * The full database is ~9.6 MB and covers almost every cellular device
+ * ever made. For the testbench we only need a plausible sample of
+ * roughly the last 10 years of popular handsets, so this script picks
+ * out a hand-curated subset by exact model-name match against the
+ * `MODEL_PICKS` table below.
+ *
+ * Usage (from `web/`):
+ *   curl -sSL http://tacdb.osmocom.org/export/tacdb.json -o /tmp/tacdb.json
+ *   node scripts/extract-tac-catalog.mjs /tmp/tacdb.json \
+ *        src/mocks/data/tacCatalog.json
+ *
+ * Re-run after adding/removing entries in `MODEL_PICKS` or when a fresh
+ * snapshot of the upstream database is needed. The output is committed
+ * to the repo — this script is not run at build time.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+
+/**
+ * Hand-picked models per brand. Matched case-sensitively against the
+ * upstream `brands[<brand>].models[<i>][<modelName>]` key. When a pick
+ * resolves to more than one TAC in the upstream DB (common — different
+ * regional SKUs get different TACs) the first one is taken. `year` is
+ * editorial — the upstream DB doesn't expose a release year.
+ */
+/**
+ * Note on coverage: the upstream Osmocom TAC DB is community-maintained
+ * and its coverage of post-2019 flagships is patchy. The picks below are
+ * limited to models for which the DB actually holds a TAC — enough for
+ * a plausible testbench but not a comprehensive catalogue. Re-run this
+ * script with a fresher snapshot if upstream data improves.
+ */
+const MODEL_PICKS = {
+  Apple: [
+    ['iPhone 5', 2012],
+    ['iPhone 6', 2014],
+    ['iPhone 6s', 2015],
+    ['iPhone SE', 2016],
+    ['iPhone 7', 2016],
+    ['iPhone 7 Plus', 2016],
+    ['iPhone 8', 2017],
+    ['iPhone 13', 2021],
+  ],
+  Samsung: [
+    ['Galaxy S5', 2014],
+    ['Galaxy S7', 2016],
+    ['Galaxy Note8', 2017],
+    ['Galaxy Note 8 LTE', 2017],
+  ],
+  Google: [
+    ['Pixel 2', 2017],
+    ['Pixel 3', 2018],
+    ['Pixel 4', 2019],
+    ['Pixel 4a', 2020],
+    ['Pixel XL', 2016],
+  ],
+  Xiaomi: [
+    ['Mi A1', 2017],
+    ['Mi 4i', 2015],
+    ['Redmi Note 3', 2016],
+    ['Redmi Note 7', 2019],
+    ['Redmi 8A', 2019],
+    ['Redmi 9A', 2020],
+  ],
+  Huawei: [
+    ['P20 Pro', 2018],
+    ['P20 lite', 2018],
+    ['Mate 9', 2016],
+  ],
+  Sony: [
+    ['Xperia XA2', 2018],
+    ['Xperia Z3C', 2014],
+  ],
+  Motorola: [
+    ['Moto G (4)', 2016],
+    ['Moto G5', 2017],
+    ['Moto G4 Plus', 2016],
+    ['Moto G4 Play', 2016],
+    ['Moto E', 2014],
+  ],
+};
+
+const [, , inputPath, outputPath] = process.argv;
+if (!inputPath || !outputPath) {
+  console.error('Usage: extract-tac-catalog.mjs <osmocom-tacdb.json> <output.json>');
+  process.exit(2);
+}
+
+const raw = JSON.parse(readFileSync(inputPath, 'utf8'));
+if (!raw.brands) {
+  console.error('Input does not look like an Osmocom TAC DB export (no `brands` key).');
+  process.exit(1);
+}
+
+/** @type {{tac: string, manufacturer: string, model: string, year?: number}[]} */
+const entries = [];
+const missing = [];
+
+for (const [brand, picks] of Object.entries(MODEL_PICKS)) {
+  const brandEntry = raw.brands[brand];
+  if (!brandEntry) {
+    missing.push(`brand not found: ${brand}`);
+    continue;
+  }
+  // Build a case-insensitive index so "Galaxy S23" matches whatever casing
+  // the upstream uses (varies by brand).
+  const index = new Map();
+  for (const modelWrap of brandEntry.models) {
+    for (const [modelName, modelInfo] of Object.entries(modelWrap)) {
+      index.set(modelName.toLowerCase(), { modelName, modelInfo });
+    }
+  }
+  for (const [wantedName, year] of picks) {
+    const hit = index.get(wantedName.toLowerCase());
+    if (!hit || !hit.modelInfo.tacs || hit.modelInfo.tacs.length === 0) {
+      missing.push(`${brand} / ${wantedName}`);
+      continue;
+    }
+    entries.push({
+      tac: hit.modelInfo.tacs[0],
+      manufacturer: brand,
+      // Use whatever name the upstream DB carries — canonicalises casing.
+      model: hit.modelName,
+      year,
+    });
+  }
+}
+
+// Stable ordering: by manufacturer, then by year ascending, then by model.
+entries.sort(
+  (a, b) =>
+    a.manufacturer.localeCompare(b.manufacturer) ||
+    (a.year ?? 0) - (b.year ?? 0) ||
+    a.model.localeCompare(b.model),
+);
+
+writeFileSync(
+  outputPath,
+  JSON.stringify(
+    {
+      $schema: {
+        description:
+          'Curated TAC catalogue extracted from the Osmocom TAC database.',
+        source: 'http://tacdb.osmocom.org/export/tacdb.json',
+        licence: 'CC-BY-SA v3.0 — © Harald Welte 2016',
+        extractedAt: new Date().toISOString(),
+        extractor: 'web/scripts/extract-tac-catalog.mjs',
+      },
+      entries,
+    },
+    null,
+    2,
+  ),
+);
+
+console.log(`Wrote ${entries.length} entries to ${outputPath}`);
+if (missing.length > 0) {
+  console.warn(`\nSkipped (not in upstream DB):\n  ${missing.join('\n  ')}`);
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,6 +12,7 @@ import { AppShell } from './layout/AppShell';
 import { DashboardPage } from './pages/dashboard/DashboardPage';
 import { PeersPage } from './pages/peers/PeersPage';
 import { PlaceholderPage } from './pages/PlaceholderPage';
+import { SettingsPage } from './pages/settings/SettingsPage';
 import { SubscribersPage } from './pages/subscribers/SubscribersPage';
 
 const queryClient = createQueryClient();
@@ -41,10 +42,7 @@ export function App() {
                 path="execution"
                 element={<PlaceholderPage title="Executions" />}
               />
-              <Route
-                path="settings"
-                element={<PlaceholderPage title="Settings" />}
-              />
+              <Route path="settings" element={<SettingsPage />} />
             </Route>
           </Routes>
           </SseProvider>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,6 +12,7 @@ import { AppShell } from './layout/AppShell';
 import { DashboardPage } from './pages/dashboard/DashboardPage';
 import { PeersPage } from './pages/peers/PeersPage';
 import { PlaceholderPage } from './pages/PlaceholderPage';
+import { SubscribersPage } from './pages/subscribers/SubscribersPage';
 
 const queryClient = createQueryClient();
 
@@ -27,10 +28,7 @@ export function App() {
             <Route element={<AppShell />}>
               <Route index element={<DashboardPage />} />
               <Route path="peers" element={<PeersPage />} />
-              <Route
-                path="subscribers"
-                element={<PlaceholderPage title="Subscribers" />}
-              />
+              <Route path="subscribers" element={<SubscribersPage />} />
               <Route
                 path="templates"
                 element={<PlaceholderPage title="AVP Templates" />}

--- a/web/src/api/iccid.ts
+++ b/web/src/api/iccid.ts
@@ -1,0 +1,50 @@
+/**
+ * ICCID helpers — SIM serial composition with Luhn check digit.
+ *
+ * An ICCID (ITU-T E.118) is 19 or 20 digits:
+ *   ┌ 2 ┬ MCC+MNC (5–6) ┬ serial (10–12) ┬ 1 ┐
+ *   │89 │  MCCMNC       │   account      │L │
+ *   └───┴───────────────┴────────────────┴──┘
+ *
+ * The real spec uses an E.164 country code plus an issuer identifier,
+ * but for a testbench we key off MCCMNC (Mobile Country Code + Mobile
+ * Network Code — the same value operators embed in the IMSI) because
+ * that's what the operator has in their provisioning system.
+ *
+ * The final digit is a Luhn mod-10 check over the preceding digits.
+ * We reuse `luhnCheckDigit` from `./imei` so both identifiers share a
+ * single checksum implementation.
+ */
+
+import { luhnCheckDigit } from './imei';
+
+/** True when `iccid` is a 19- or 20-digit string with a valid Luhn check. */
+export function isValidIccid(iccid: string): boolean {
+  if (!/^[0-9]{19,20}$/.test(iccid)) return false;
+  const check = luhnCheckDigit(iccid.slice(0, -1));
+  return check === Number(iccid[iccid.length - 1]);
+}
+
+/**
+ * Compose an ICCID from an MCCMNC (5 or 6 digits) and an optional
+ * account serial. When the serial is omitted, it is rolled randomly
+ * and the result is a 19-digit ICCID (the common case).
+ *
+ * Returns `undefined` when the MCCMNC is malformed.
+ */
+export function buildIccid(
+  mccmnc: string,
+  serial?: string,
+): string | undefined {
+  if (!/^[0-9]{5,6}$/.test(mccmnc)) return undefined;
+  // Default to a 19-digit ICCID: 2 (89) + mccmnc + serial + 1 (check).
+  const serialLen = 19 - 1 - 2 - mccmnc.length;
+  const s =
+    serial ??
+    Array.from({ length: serialLen }, () =>
+      Math.floor(Math.random() * 10).toString(),
+    ).join('');
+  if (!new RegExp(`^[0-9]{${serialLen}}$`).test(s)) return undefined;
+  const base = `89${mccmnc}${s}`;
+  return base + luhnCheckDigit(base).toString();
+}

--- a/web/src/api/imei.ts
+++ b/web/src/api/imei.ts
@@ -1,0 +1,55 @@
+/**
+ * IMEI helpers — Luhn check-digit and IMEI composition.
+ *
+ * An IMEI is 15 digits:
+ *   ┌ 8 digits ┬ 6 digits ┬ 1 digit ┐
+ *   │   TAC    │  serial  │  Luhn   │
+ *   └──────────┴──────────┴─────────┘
+ *
+ * The TAC (Type Allocation Code) identifies the device manufacturer +
+ * model. The serial is assigned by the manufacturer. The final digit is
+ * a Luhn mod-10 check over the first 14 digits.
+ *
+ * These helpers live under `api/` rather than a UI component because the
+ * same rules are enforced by the backend — parity is easier to keep when
+ * the definitions sit alongside the API schema types.
+ */
+
+/**
+ * Compute the Luhn check digit (single digit, 0–9) for the given digit
+ * string. Pass in the first 14 digits of an IMEI to derive the 15th.
+ * Returns -1 for non-digit input.
+ */
+export function luhnCheckDigit(digits: string): number {
+  if (!/^[0-9]+$/.test(digits)) return -1;
+  // Walk right-to-left doubling every second digit (the ones in the
+  // even-indexed positions from the right, i.e. the ones immediately
+  // "below" the check-digit position).
+  let sum = 0;
+  for (let i = 0; i < digits.length; i++) {
+    const d = digits.charCodeAt(digits.length - 1 - i) - 48;
+    const doubled = i % 2 === 0 ? d * 2 : d;
+    sum += doubled > 9 ? doubled - 9 : doubled;
+  }
+  return (10 - (sum % 10)) % 10;
+}
+
+/** True when `imei` is a 15-digit string with a valid Luhn check digit. */
+export function isValidImei(imei: string): boolean {
+  if (!/^[0-9]{15}$/.test(imei)) return false;
+  const check = luhnCheckDigit(imei.slice(0, 14));
+  return check === Number(imei[14]);
+}
+
+/**
+ * Compose a full IMEI from an 8-digit TAC and an optional 6-digit
+ * serial. When the serial is omitted, six random digits are rolled.
+ * Returns `undefined` when the TAC is malformed.
+ */
+export function buildImei(tac: string, serial?: string): string | undefined {
+  if (!/^[0-9]{8}$/.test(tac)) return undefined;
+  const s = serial ?? String(Math.floor(Math.random() * 1_000_000)).padStart(6, '0');
+  if (!/^[0-9]{6}$/.test(s)) return undefined;
+  const base = tac + s;
+  return base + luhnCheckDigit(base).toString();
+}

--- a/web/src/api/resources/subscribers.ts
+++ b/web/src/api/resources/subscribers.ts
@@ -1,34 +1,109 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import ApiService from '../ApiService';
 import type { components } from '../schema';
 
 export type Subscriber = components['schemas']['Subscriber'];
-export type SubscriberPage = components['schemas']['SubscriberPage'];
-
-export interface ListSubscribersParams {
-  limit?: number;
-  offset?: number;
-}
+export type SubscriberInput = components['schemas']['SubscriberInput'];
+export type TacEntry = components['schemas']['TacEntry'];
 
 export const subscriberKeys = {
   all: ['subscribers'] as const,
-  list: (params: ListSubscribersParams = {}) =>
-    [...subscriberKeys.all, 'list', params] as const,
+  list: () => [...subscriberKeys.all, 'list'] as const,
+  detail: (id: string) => [...subscriberKeys.all, 'detail', id] as const,
 };
 
-export const listSubscribers = (
-  params: ListSubscribersParams = {},
-  signal?: AbortSignal,
-) =>
-  ApiService.get<SubscriberPage>('/subscribers', {
-    params,
-    signal,
-  });
+export const tacKeys = {
+  all: ['tac-catalog'] as const,
+  list: () => [...tacKeys.all, 'list'] as const,
+};
 
-export function useSubscribers(params: ListSubscribersParams = {}) {
+export const listSubscribers = (signal?: AbortSignal) =>
+  ApiService.get<Subscriber[]>('/subscribers', { signal });
+
+export const getSubscriber = (id: string, signal?: AbortSignal) =>
+  ApiService.get<Subscriber>(
+    `/subscribers/${encodeURIComponent(id)}`,
+    { signal },
+  );
+
+export const createSubscriber = (input: SubscriberInput) =>
+  ApiService.post<Subscriber, SubscriberInput>('/subscribers', input);
+
+export const updateSubscriber = (id: string, input: SubscriberInput) =>
+  ApiService.put<Subscriber, SubscriberInput>(
+    `/subscribers/${encodeURIComponent(id)}`,
+    input,
+  );
+
+export const deleteSubscriber = (id: string) =>
+  ApiService.delete<void>(`/subscribers/${encodeURIComponent(id)}`);
+
+export const listTacCatalog = (signal?: AbortSignal) =>
+  ApiService.get<TacEntry[]>('/tac-catalog', { signal });
+
+export function useSubscribers() {
   return useQuery({
-    queryKey: subscriberKeys.list(params),
-    queryFn: ({ signal }) => listSubscribers(params, signal),
+    queryKey: subscriberKeys.list(),
+    queryFn: ({ signal }) => listSubscribers(signal),
+  });
+}
+
+export function useSubscriber(id: string | undefined) {
+  return useQuery({
+    queryKey: id ? subscriberKeys.detail(id) : subscriberKeys.all,
+    queryFn: ({ signal }) => getSubscriber(id!, signal),
+    enabled: Boolean(id),
+  });
+}
+
+/**
+ * Curated TAC catalogue used to populate Manufacturer → Model selects
+ * and to derive IMEI prefixes. The data is server-immutable, so it is
+ * marked `staleTime: Infinity` — one fetch per session is plenty.
+ */
+export function useTacCatalog() {
+  return useQuery({
+    queryKey: tacKeys.list(),
+    queryFn: ({ signal }) => listTacCatalog(signal),
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+}
+
+export function useCreateSubscriber() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: SubscriberInput) => createSubscriber(input),
+    onSuccess: (sub) => {
+      qc.setQueryData(subscriberKeys.detail(sub.id), sub);
+      void qc.invalidateQueries({ queryKey: subscriberKeys.list() });
+    },
+  });
+}
+
+export function useUpdateSubscriber(id: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: SubscriberInput) => updateSubscriber(id, input),
+    onSuccess: (sub) => {
+      qc.setQueryData(subscriberKeys.detail(sub.id), sub);
+      qc.setQueryData<Subscriber[]>(subscriberKeys.list(), (prev) =>
+        prev ? prev.map((p) => (p.id === sub.id ? sub : p)) : prev,
+      );
+    },
+  });
+}
+
+export function useDeleteSubscriber() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deleteSubscriber(id).then(() => id),
+    onSuccess: (id) => {
+      qc.removeQueries({ queryKey: subscriberKeys.detail(id) });
+      qc.setQueryData<Subscriber[]>(subscriberKeys.list(), (prev) =>
+        prev ? prev.filter((s) => s.id !== id) : prev,
+      );
+    },
   });
 }

--- a/web/src/api/schema.d.ts
+++ b/web/src/api/schema.d.ts
@@ -619,13 +619,8 @@ export interface components {
         Subscriber: {
             id: string;
             /**
-             * @description Human-readable label for this subscriber
-             * @example Alice Test
-             */
-            name: string;
-            /**
-             * @description E.164-style MSISDN, digits only (no `+` prefix). Unique across
-             *     subscribers.
+             * @description E.164-style MSISDN, digits only (no `+` prefix). The primary
+             *     identifier of a subscriber; unique across subscribers.
              * @example 27821234567
              */
             msisdn: string;
@@ -657,7 +652,6 @@ export interface components {
          *     (POST /subscribers) and replace (PUT /subscribers/{id}).
          */
         SubscriberInput: {
-            name: string;
             msisdn: string;
             iccid: string;
             /**

--- a/web/src/api/schema.d.ts
+++ b/web/src/api/schema.d.ts
@@ -217,8 +217,71 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List subscribers (paginated) */
+        /**
+         * List subscribers
+         * @description Returns every configured subscriber. The testbench is expected to
+         *     hold at most a few thousand subscribers so the list is returned
+         *     unpaginated — the UI does client-side search/filter.
+         */
         get: operations["listSubscribers"];
+        put?: never;
+        /** Create a new subscriber */
+        post: operations["createSubscriber"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/subscribers/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Resource identifier */
+                id: components["parameters"]["IdPath"];
+            };
+            cookie?: never;
+        };
+        /** Get a single subscriber by id */
+        get: operations["getSubscriber"];
+        /** Replace a subscriber's configuration */
+        put: operations["updateSubscriber"];
+        post?: never;
+        /** Delete a subscriber */
+        delete: operations["deleteSubscriber"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/tac-catalog": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Curated TAC (Type Allocation Code) catalogue
+         * @description Returns the curated list of device manufacturer/model combinations
+         *     supported by this testbench, each with its 8-digit TAC prefix.
+         *     The catalogue covers roughly the last 10 years of popular handsets
+         *     across major OEMs — it is intentionally a small curated set rather
+         *     than the full GSMA TAC database.
+         *
+         *     The UI uses this to:
+         *     - populate cascading Manufacturer → Model selects on the
+         *       subscriber edit drawer
+         *     - derive the TAC prefix used when generating an IMEI
+         *     - display the canonical "Device" label on the subscribers list
+         *       (e.g. `iPhone 14 Pro` is reconstructed from the `tac` on a
+         *       `Subscriber` by looking it up here)
+         *
+         *     Returned items are immutable on the server side and may be cached
+         *     aggressively by clients (`ETag` / `Cache-Control: public`).
+         */
+        get: operations["listTacCatalog"];
         put?: never;
         post?: never;
         delete?: never;
@@ -547,17 +610,85 @@ export interface components {
             /** @description Human-readable detail (e.g. 'CER/CEA timeout', 'handshake OK') */
             detail?: string;
         };
+        /**
+         * @description A subscriber identity used by test scenarios. Carries the SIM
+         *     credentials (MSISDN + ICCID), an optional device binding
+         *     (Manufacturer + Model, expressed server-side as a TAC prefix), and
+         *     an optional IMEI (only meaningful when a device is bound).
+         */
         Subscriber: {
             id: string;
-            /** @description Subscriber MSISDN */
+            /**
+             * @description Human-readable label for this subscriber
+             * @example Alice Test
+             */
+            name: string;
+            /**
+             * @description E.164-style MSISDN, digits only (no `+` prefix). Unique across
+             *     subscribers.
+             * @example 27821234567
+             */
             msisdn: string;
-            imsi?: string;
+            /**
+             * @description Integrated Circuit Card Identifier (SIM serial), 19 or 20
+             *     digits. Unique across subscribers.
+             * @example 89270100001234567890
+             */
+            iccid: string;
+            /**
+             * @description 8-digit Type Allocation Code identifying the device
+             *     manufacturer + model. When present, the server recognises it
+             *     as one of the catalogue entries at `GET /tac-catalog` and
+             *     the UI looks up Manufacturer/Model labels from there.
+             * @example 35398506
+             */
+            tac?: string;
+            /**
+             * @description 15-digit IMEI (TAC + 6 serial + Luhn check digit). Only
+             *     present when a device is bound (`tac` is set). Not unique —
+             *     the same physical device can legitimately be paired with
+             *     multiple test subscribers.
+             * @example 353985067894321
+             */
             imei?: string;
-            notes?: string;
         };
-        SubscriberPage: {
-            items: components["schemas"]["Subscriber"][];
-            page: components["schemas"]["PageMeta"];
+        /**
+         * @description Writable subset of `Subscriber`. Used for both create
+         *     (POST /subscribers) and replace (PUT /subscribers/{id}).
+         */
+        SubscriberInput: {
+            name: string;
+            msisdn: string;
+            iccid: string;
+            /**
+             * @description Optional 8-digit TAC. When set, must match an entry in
+             *     `GET /tac-catalog` — the server will reject unknown TACs with
+             *     a 422.
+             */
+            tac?: string;
+            /**
+             * @description Optional 15-digit IMEI. Must be Luhn-valid and, when `tac`
+             *     is also set, must share the same 8-digit prefix as `tac`.
+             *     Rejected with 422 otherwise.
+             */
+            imei?: string;
+        };
+        /**
+         * @description One entry in the curated TAC catalogue. Identifies a single
+         *     manufacturer/model combination by its 8-digit TAC prefix.
+         */
+        TacEntry: {
+            /**
+             * @description 8-digit Type Allocation Code
+             * @example 35398506
+             */
+            tac: string;
+            /** @example Apple */
+            manufacturer: string;
+            /** @example iPhone 14 Pro */
+            model: string;
+            /** @description Release year (informational) */
+            year?: number;
         };
         TemplateSummary: {
             id: string;
@@ -999,25 +1130,145 @@ export interface operations {
     };
     listSubscribers: {
         parameters: {
-            query?: {
-                /** @description Maximum number of items to return */
-                limit?: components["parameters"]["LimitQuery"];
-                /** @description Number of items to skip */
-                offset?: components["parameters"]["OffsetQuery"];
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
         requestBody?: never;
         responses: {
-            /** @description Paginated subscriber list */
+            /** @description Subscriber list */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SubscriberPage"];
+                    "application/json": components["schemas"]["Subscriber"][];
+                };
+            };
+            default: components["responses"]["Problem"];
+        };
+    };
+    createSubscriber: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SubscriberInput"];
+            };
+        };
+        responses: {
+            /** @description Subscriber created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Subscriber"];
+                };
+            };
+            422: components["responses"]["ValidationProblem"];
+            default: components["responses"]["Problem"];
+        };
+    };
+    getSubscriber: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Resource identifier */
+                id: components["parameters"]["IdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Subscriber detail */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Subscriber"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            default: components["responses"]["Problem"];
+        };
+    };
+    updateSubscriber: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Resource identifier */
+                id: components["parameters"]["IdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SubscriberInput"];
+            };
+        };
+        responses: {
+            /** @description Subscriber updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Subscriber"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationProblem"];
+            default: components["responses"]["Problem"];
+        };
+    };
+    deleteSubscriber: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Resource identifier */
+                id: components["parameters"]["IdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Subscriber deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            404: components["responses"]["NotFound"];
+            default: components["responses"]["Problem"];
+        };
+    };
+    listTacCatalog: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description TAC catalogue */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TacEntry"][];
                 };
             };
             default: components["responses"]["Problem"];

--- a/web/src/mocks/data/subscribers.ts
+++ b/web/src/mocks/data/subscribers.ts
@@ -1,18 +1,61 @@
 import type { Subscriber } from '../../api/resources/subscribers';
+import { buildImei } from '../../api/imei';
 
-const TOTAL = 142;
+/**
+ * Five subscribers matching the Figma "Subscribers / Light" screen.
+ * Names / MSISDN / ICCID come from the design; IMEIs are composed
+ * from the TAC picked for each subscriber so they Luhn-validate.
+ *
+ * Two subscribers (Charlie Pool, Eve Testbench) are deliberately left
+ * without a device binding so the empty-device "—" rendering is
+ * exercised on the list screen.
+ */
+// Values must match entries in src/mocks/data/tacCatalog.json.
+const TAC_APPLE_IPHONE_7 = '35656108';
+const TAC_APPLE_IPHONE_13 = '35104463';
+const TAC_GOOGLE_PIXEL_4 = '35293110';
 
-/** Generate a deterministic set of 142 subscribers. */
-export const subscriberFixtures: Subscriber[] = Array.from(
-  { length: TOTAL },
-  (_, i): Subscriber => {
-    const n = i + 1;
-    const msisdn = `64210${String(100000 + n).padStart(6, '0')}`;
-    const imsi = `530017${String(1000000 + n).padStart(8, '0')}`;
-    return {
-      id: `sub-${String(n).padStart(4, '0')}`,
-      msisdn,
-      imsi,
-    };
+// Fixed serials (rather than random) so fixtures are deterministic
+// across reloads — handy for screenshot tests and debugging.
+const imeiFor = (tac: string, serial: string): string =>
+  buildImei(tac, serial)!;
+
+export const subscriberFixtures: Subscriber[] = [
+  {
+    id: 'sub-01',
+    name: 'Alice Test',
+    msisdn: '27821234567',
+    iccid: '89270100001234567890',
+    tac: TAC_APPLE_IPHONE_13,
+    imei: imeiFor(TAC_APPLE_IPHONE_13, '678943'),
   },
-);
+  {
+    id: 'sub-02',
+    name: 'Bob Demo',
+    msisdn: '27837654321',
+    iccid: '89270100009876543210',
+    tac: TAC_APPLE_IPHONE_7,
+    imei: imeiFor(TAC_APPLE_IPHONE_7, '678124'),
+  },
+  {
+    id: 'sub-03',
+    name: 'Charlie Pool',
+    msisdn: '27831122334',
+    iccid: '89270100005544332211',
+    // No device bound — list shows "—".
+  },
+  {
+    id: 'sub-04',
+    name: 'Diana Load',
+    msisdn: '27839988776',
+    iccid: '89270100003344556677',
+    tac: TAC_GOOGLE_PIXEL_4,
+    imei: imeiFor(TAC_GOOGLE_PIXEL_4, '301234'),
+  },
+  {
+    id: 'sub-05',
+    name: 'Eve Testbench',
+    msisdn: '27835566778',
+    iccid: '89270100007788990011',
+  },
+];

--- a/web/src/mocks/data/subscribers.ts
+++ b/web/src/mocks/data/subscribers.ts
@@ -3,10 +3,10 @@ import { buildImei } from '../../api/imei';
 
 /**
  * Five subscribers matching the Figma "Subscribers / Light" screen.
- * Names / MSISDN / ICCID come from the design; IMEIs are composed
- * from the TAC picked for each subscriber so they Luhn-validate.
+ * MSISDN / ICCID come from the design; IMEIs are composed from the TAC
+ * picked for each subscriber so they Luhn-validate.
  *
- * Two subscribers (Charlie Pool, Eve Testbench) are deliberately left
+ * Two subscribers (27831122334, 27835566778) are deliberately left
  * without a device binding so the empty-device "—" rendering is
  * exercised on the list screen.
  */
@@ -23,7 +23,6 @@ const imeiFor = (tac: string, serial: string): string =>
 export const subscriberFixtures: Subscriber[] = [
   {
     id: 'sub-01',
-    name: 'Alice Test',
     msisdn: '27821234567',
     iccid: '89270100001234567890',
     tac: TAC_APPLE_IPHONE_13,
@@ -31,7 +30,6 @@ export const subscriberFixtures: Subscriber[] = [
   },
   {
     id: 'sub-02',
-    name: 'Bob Demo',
     msisdn: '27837654321',
     iccid: '89270100009876543210',
     tac: TAC_APPLE_IPHONE_7,
@@ -39,14 +37,12 @@ export const subscriberFixtures: Subscriber[] = [
   },
   {
     id: 'sub-03',
-    name: 'Charlie Pool',
     msisdn: '27831122334',
     iccid: '89270100005544332211',
     // No device bound — list shows "—".
   },
   {
     id: 'sub-04',
-    name: 'Diana Load',
     msisdn: '27839988776',
     iccid: '89270100003344556677',
     tac: TAC_GOOGLE_PIXEL_4,
@@ -54,7 +50,6 @@ export const subscriberFixtures: Subscriber[] = [
   },
   {
     id: 'sub-05',
-    name: 'Eve Testbench',
     msisdn: '27835566778',
     iccid: '89270100007788990011',
   },

--- a/web/src/mocks/data/tacCatalog.json
+++ b/web/src/mocks/data/tacCatalog.json
@@ -1,0 +1,209 @@
+{
+  "$schema": {
+    "description": "Curated TAC catalogue extracted from the Osmocom TAC database.",
+    "source": "http://tacdb.osmocom.org/export/tacdb.json",
+    "licence": "CC-BY-SA v3.0 — © Harald Welte 2016",
+    "extractedAt": "2026-04-21T11:54:12.301Z",
+    "extractor": "web/scripts/extract-tac-catalog.mjs"
+  },
+  "entries": [
+    {
+      "tac": "01334500",
+      "manufacturer": "Apple",
+      "model": "iPhone 5",
+      "year": 2012
+    },
+    {
+      "tac": "35539407",
+      "manufacturer": "Apple",
+      "model": "iPhone 6",
+      "year": 2014
+    },
+    {
+      "tac": "35380108",
+      "manufacturer": "Apple",
+      "model": "iPhone 6s",
+      "year": 2015
+    },
+    {
+      "tac": "35656108",
+      "manufacturer": "Apple",
+      "model": "iPhone 7",
+      "year": 2016
+    },
+    {
+      "tac": "35381208",
+      "manufacturer": "Apple",
+      "model": "iPhone 7 Plus",
+      "year": 2016
+    },
+    {
+      "tac": "35544207",
+      "manufacturer": "Apple",
+      "model": "iPhone SE",
+      "year": 2016
+    },
+    {
+      "tac": "35676300",
+      "manufacturer": "Apple",
+      "model": "iPhone 8",
+      "year": 2017
+    },
+    {
+      "tac": "35104463",
+      "manufacturer": "Apple",
+      "model": "iPhone 13",
+      "year": 2021
+    },
+    {
+      "tac": "35267708",
+      "manufacturer": "Google",
+      "model": "Pixel XL",
+      "year": 2016
+    },
+    {
+      "tac": "35753708",
+      "manufacturer": "Google",
+      "model": "Pixel 2",
+      "year": 2017
+    },
+    {
+      "tac": "35827609",
+      "manufacturer": "Google",
+      "model": "Pixel 3",
+      "year": 2018
+    },
+    {
+      "tac": "35293110",
+      "manufacturer": "Google",
+      "model": "Pixel 4",
+      "year": 2019
+    },
+    {
+      "tac": "35751110",
+      "manufacturer": "Google",
+      "model": "Pixel 4a",
+      "year": 2020
+    },
+    {
+      "tac": "86200503",
+      "manufacturer": "Huawei",
+      "model": "Mate 9",
+      "year": 2016
+    },
+    {
+      "tac": "86344104",
+      "manufacturer": "Huawei",
+      "model": "P20 lite",
+      "year": 2018
+    },
+    {
+      "tac": "86908403",
+      "manufacturer": "Huawei",
+      "model": "P20 Pro",
+      "year": 2018
+    },
+    {
+      "tac": "35333106",
+      "manufacturer": "Motorola",
+      "model": "Moto E",
+      "year": 2014
+    },
+    {
+      "tac": "35412407",
+      "manufacturer": "Motorola",
+      "model": "Moto G (4)",
+      "year": 2016
+    },
+    {
+      "tac": "35414507",
+      "manufacturer": "Motorola",
+      "model": "Moto G4 Play",
+      "year": 2016
+    },
+    {
+      "tac": "35411707",
+      "manufacturer": "Motorola",
+      "model": "Moto G4 Plus",
+      "year": 2016
+    },
+    {
+      "tac": "35187008",
+      "manufacturer": "Motorola",
+      "model": "Moto G5",
+      "year": 2017
+    },
+    {
+      "tac": "35372606",
+      "manufacturer": "Samsung",
+      "model": "Galaxy S5",
+      "year": 2014
+    },
+    {
+      "tac": "35815207",
+      "manufacturer": "Samsung",
+      "model": "Galaxy S7",
+      "year": 2016
+    },
+    {
+      "tac": "35200309",
+      "manufacturer": "Samsung",
+      "model": "Galaxy Note 8 LTE",
+      "year": 2017
+    },
+    {
+      "tac": "35345678",
+      "manufacturer": "Samsung",
+      "model": "Galaxy Note8",
+      "year": 2017
+    },
+    {
+      "tac": "35517906",
+      "manufacturer": "Sony",
+      "model": "Xperia Z3C",
+      "year": 2014
+    },
+    {
+      "tac": "35276509",
+      "manufacturer": "Sony",
+      "model": "Xperia XA2",
+      "year": 2018
+    },
+    {
+      "tac": "86763402",
+      "manufacturer": "Xiaomi",
+      "model": "Mi 4i",
+      "year": 2015
+    },
+    {
+      "tac": "86927102",
+      "manufacturer": "Xiaomi",
+      "model": "Redmi Note 3",
+      "year": 2016
+    },
+    {
+      "tac": "86861703",
+      "manufacturer": "Xiaomi",
+      "model": "Mi A1",
+      "year": 2017
+    },
+    {
+      "tac": "86326504",
+      "manufacturer": "Xiaomi",
+      "model": "Redmi 8A",
+      "year": 2019
+    },
+    {
+      "tac": "86247104",
+      "manufacturer": "Xiaomi",
+      "model": "Redmi Note 7",
+      "year": 2019
+    },
+    {
+      "tac": "86751306",
+      "manufacturer": "Xiaomi",
+      "model": "Redmi 9A",
+      "year": 2020
+    }
+  ]
+}

--- a/web/src/mocks/fakeApi/subscribersFakeApi.ts
+++ b/web/src/mocks/fakeApi/subscribersFakeApi.ts
@@ -32,14 +32,10 @@ function validate(
   excludeId?: string,
 ): FieldErrors | null {
   const errors: FieldErrors = {};
-  const name = input?.name?.trim();
   const msisdn = input?.msisdn?.trim();
   const iccid = input?.iccid?.trim();
   const tac = input?.tac?.trim() || undefined;
   const imei = input?.imei?.trim() || undefined;
-
-  if (!name) errors['/name'] = ['Name is required'];
-  else if (name.length > 64) errors['/name'] = ['Name must be 64 chars or less'];
 
   if (!msisdn) errors['/msisdn'] = ['MSISDN is required'];
   else if (!/^[0-9]{8,15}$/.test(msisdn))
@@ -96,7 +92,6 @@ function validationProblem(
 function applyInput(base: Partial<Subscriber>, input: SubscriberInput): Subscriber {
   return {
     id: base.id!,
-    name: input.name,
     msisdn: input.msisdn,
     iccid: input.iccid,
     tac: input.tac || undefined,

--- a/web/src/mocks/fakeApi/subscribersFakeApi.ts
+++ b/web/src/mocks/fakeApi/subscribersFakeApi.ts
@@ -1,19 +1,214 @@
-import type { SubscriberPage } from '../../api/resources/subscribers';
+import type {
+  Subscriber,
+  SubscriberInput,
+  TacEntry,
+} from '../../api/resources/subscribers';
+import { isValidImei } from '../../api/imei';
 import { subscriberFixtures } from '../data/subscribers';
+import tacCatalogDoc from '../data/tacCatalog.json';
 import { mock } from '../MockAdapter';
 
+/** Working copy so POST/PUT/DELETE survive across calls within a session. */
+const subscribers: Subscriber[] = subscriberFixtures.map((s) => ({ ...s }));
+
+// Narrow the JSON-import shape to TacEntry[] — the `$schema` metadata at
+// the top of the file is intentional editorial scaffolding, not part of
+// the API response.
+const tacCatalog: TacEntry[] = (tacCatalogDoc as { entries: TacEntry[] })
+  .entries;
+const tacSet = new Set(tacCatalog.map((e) => e.tac));
+
+type FieldErrors = Record<string, string[]>;
+
+/**
+ * Minimal field validator. Patterns match the OpenAPI spec; extra
+ * cross-field rules (TAC catalogue lookup, IMEI/TAC consistency, Luhn
+ * validity) are checked here so the fake API exercises the same 422
+ * contract the real backend will.
+ */
+function validate(
+  input: Partial<SubscriberInput> | undefined,
+  existing: Subscriber[],
+  excludeId?: string,
+): FieldErrors | null {
+  const errors: FieldErrors = {};
+  const name = input?.name?.trim();
+  const msisdn = input?.msisdn?.trim();
+  const iccid = input?.iccid?.trim();
+  const tac = input?.tac?.trim() || undefined;
+  const imei = input?.imei?.trim() || undefined;
+
+  if (!name) errors['/name'] = ['Name is required'];
+  else if (name.length > 64) errors['/name'] = ['Name must be 64 chars or less'];
+
+  if (!msisdn) errors['/msisdn'] = ['MSISDN is required'];
+  else if (!/^[0-9]{8,15}$/.test(msisdn))
+    errors['/msisdn'] = ['MSISDN must be 8–15 digits'];
+  else if (
+    existing.some((s) => s.id !== excludeId && s.msisdn === msisdn)
+  )
+    errors['/msisdn'] = [`MSISDN "${msisdn}" is already in use`];
+
+  if (!iccid) errors['/iccid'] = ['ICCID is required'];
+  else if (!/^[0-9]{19,20}$/.test(iccid))
+    errors['/iccid'] = ['ICCID must be 19 or 20 digits'];
+  else if (
+    existing.some((s) => s.id !== excludeId && s.iccid === iccid)
+  )
+    errors['/iccid'] = [`ICCID "${iccid}" is already in use`];
+
+  if (tac !== undefined) {
+    if (!/^[0-9]{8}$/.test(tac))
+      errors['/tac'] = ['TAC must be 8 digits'];
+    else if (!tacSet.has(tac))
+      errors['/tac'] = ['TAC is not in the catalogue'];
+  }
+
+  if (imei !== undefined) {
+    if (!/^[0-9]{15}$/.test(imei))
+      errors['/imei'] = ['IMEI must be 15 digits'];
+    else if (!isValidImei(imei))
+      errors['/imei'] = ['IMEI has an invalid Luhn check digit'];
+    else if (tac && !imei.startsWith(tac))
+      errors['/imei'] = [
+        'IMEI prefix does not match the chosen manufacturer/model',
+      ];
+  }
+
+  return Object.keys(errors).length > 0 ? errors : null;
+}
+
+function validationProblem(
+  errors: FieldErrors,
+): [number, Record<string, unknown>] {
+  return [
+    422,
+    {
+      type: 'about:blank',
+      title: 'Validation failed',
+      status: 422,
+      detail: 'One or more fields are invalid',
+      errors,
+    },
+  ];
+}
+
+function applyInput(base: Partial<Subscriber>, input: SubscriberInput): Subscriber {
+  return {
+    id: base.id!,
+    name: input.name,
+    msisdn: input.msisdn,
+    iccid: input.iccid,
+    tac: input.tac || undefined,
+    imei: input.imei || undefined,
+  };
+}
+
+// List
 mock
-  .onGet(/\/subscribers(\?|$)/)
+  .onGet(/\/subscribers$/)
   .withDelayInMs(250)
-  .reply((config): [number, SubscriberPage] => {
-    const limit = Math.min(500, Math.max(1, Number(config.params?.limit ?? 50)));
-    const offset = Math.max(0, Number(config.params?.offset ?? 0));
-    const items = subscriberFixtures.slice(offset, offset + limit);
+  .reply(() => [200, subscribers]);
+
+// Detail
+mock.onGet(/\/subscribers\/[^/]+$/).reply((config) => {
+  const m = /\/subscribers\/([^/]+)$/.exec(config.url ?? '');
+  const id = m ? decodeURIComponent(m[1]) : '';
+  const sub = subscribers.find((s) => s.id === id);
+  if (!sub) {
     return [
-      200,
+      404,
       {
-        items,
-        page: { total: subscriberFixtures.length, limit, offset },
+        type: 'about:blank',
+        title: 'Subscriber not found',
+        status: 404,
+        detail: `No subscriber with id "${id}"`,
       },
     ];
+  }
+  return [200, sub];
+});
+
+// Create
+mock
+  .onPost(/\/subscribers$/)
+  .withDelayInMs(300)
+  .reply((config) => {
+    const input = safeParse<SubscriberInput>(config.data);
+    const errors = validate(input, subscribers);
+    if (errors) return validationProblem(errors);
+
+    const id = `sub-${String(subscribers.length + 1).padStart(2, '0')}`;
+    const created = applyInput({ id }, input!);
+    subscribers.push(created);
+    return [201, created];
   });
+
+// Update
+mock
+  .onPut(/\/subscribers\/[^/]+$/)
+  .withDelayInMs(300)
+  .reply((config) => {
+    const m = /\/subscribers\/([^/]+)$/.exec(config.url ?? '');
+    const id = m ? decodeURIComponent(m[1]) : '';
+    const idx = subscribers.findIndex((s) => s.id === id);
+    if (idx === -1) {
+      return [
+        404,
+        {
+          type: 'about:blank',
+          title: 'Subscriber not found',
+          status: 404,
+          detail: `No subscriber with id "${id}"`,
+        },
+      ];
+    }
+
+    const input = safeParse<SubscriberInput>(config.data);
+    const errors = validate(input, subscribers, id);
+    if (errors) return validationProblem(errors);
+
+    const updated = applyInput(subscribers[idx], input!);
+    subscribers[idx] = updated;
+    return [200, updated];
+  });
+
+// Delete
+mock
+  .onDelete(/\/subscribers\/[^/]+$/)
+  .withDelayInMs(200)
+  .reply((config) => {
+    const m = /\/subscribers\/([^/]+)$/.exec(config.url ?? '');
+    const id = m ? decodeURIComponent(m[1]) : '';
+    const idx = subscribers.findIndex((s) => s.id === id);
+    if (idx === -1) {
+      return [
+        404,
+        {
+          type: 'about:blank',
+          title: 'Subscriber not found',
+          status: 404,
+          detail: `No subscriber with id "${id}"`,
+        },
+      ];
+    }
+    subscribers.splice(idx, 1);
+    return [204];
+  });
+
+// TAC catalogue — immutable; served directly from the bundled JSON.
+mock
+  .onGet(/\/tac-catalog$/)
+  .withDelayInMs(100)
+  .reply(() => [200, tacCatalog]);
+
+function safeParse<T>(data: unknown): T | undefined {
+  if (typeof data === 'string') {
+    try {
+      return JSON.parse(data) as T;
+    } catch {
+      return undefined;
+    }
+  }
+  return data as T | undefined;
+}

--- a/web/src/mocks/sse.ts
+++ b/web/src/mocks/sse.ts
@@ -5,6 +5,9 @@ import { setEventStreamFactory } from '../api/sse/transport';
 import { buildExecutionDetail, TOTAL_STEPS } from './data/executionDetails';
 import { executionFixtures } from './data/executions';
 import { peerFixtures } from './data/peers';
+import { scenarioFixtures } from './data/scenarios';
+import { subscriberFixtures } from './data/subscribers';
+import { templateFixtures } from './data/templates';
 
 /** Tick cadence — fast enough to see the UI breathe, slow enough to read. */
 const EXECUTION_TICK_MS = 2_000;
@@ -179,9 +182,9 @@ class MockSseEmitter {
       .length;
     return {
       peers: { connected, total: this.peers.length },
-      subscribers: 142,
-      templates: 8,
-      scenarios: 24,
+      subscribers: subscriberFixtures.length,
+      templates: templateFixtures.length,
+      scenarios: scenarioFixtures.length,
       activeRuns,
     };
   }

--- a/web/src/pages/settings/SettingsPage.tsx
+++ b/web/src/pages/settings/SettingsPage.tsx
@@ -1,0 +1,103 @@
+import {
+  Button,
+  Card,
+  Group,
+  Stack,
+  Text,
+  TextInput,
+  Title,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { notifications } from '@mantine/notifications';
+
+import {
+  isValidMccmnc,
+  setSettings,
+  useSettings,
+} from '../../settings/settings';
+
+/**
+ * Client-side preferences. Currently just the MCCMNC used to generate
+ * ICCIDs for new subscribers, but this is the natural home for any
+ * future UI-side defaults (notification toggles, table densities,
+ * theme overrides, etc.).
+ */
+export function SettingsPage() {
+  const settings = useSettings();
+
+  const form = useForm<{ mccmnc: string }>({
+    initialValues: { mccmnc: settings.mccmnc },
+    validateInputOnChange: true,
+    validate: {
+      mccmnc: (v) =>
+        isValidMccmnc(v.trim())
+          ? null
+          : 'MCCMNC must be 5 or 6 digits (MCC + MNC)',
+    },
+  });
+
+  const handleSubmit = form.onSubmit((values) => {
+    setSettings({ mccmnc: values.mccmnc.trim() });
+    form.resetDirty();
+    notifications.show({
+      color: 'teal',
+      title: 'Settings saved',
+      message: `MCCMNC set to ${values.mccmnc.trim()}.`,
+    });
+  });
+
+  return (
+    <Stack gap="lg" p="md">
+      <Stack gap={4}>
+        <Title order={2} fw={600}>
+          Settings
+        </Title>
+        <Text c="dimmed" size="sm">
+          Client-side preferences, stored in this browser.
+        </Text>
+      </Stack>
+
+      <Card padding="lg" withBorder shadow="xs" maw={560}>
+        <form onSubmit={handleSubmit}>
+          <Stack gap="md">
+            <Stack gap={2}>
+              <Text
+                size="xs"
+                fw={600}
+                c="dimmed"
+                tt="uppercase"
+                style={{ letterSpacing: 0.5 }}
+              >
+                SIM provisioning
+              </Text>
+              <Text size="sm" c="dimmed">
+                Used as the operator prefix when generating an ICCID for a
+                new subscriber. The first three digits are the Mobile
+                Country Code (MCC); the remainder is the Mobile Network
+                Code (MNC), two or three digits depending on the country.
+              </Text>
+            </Stack>
+
+            <TextInput
+              label="MCCMNC"
+              placeholder="65510"
+              description="5 or 6 digits (e.g. 65510 = MTN South Africa)"
+              required
+              key={form.key('mccmnc')}
+              {...form.getInputProps('mccmnc')}
+            />
+
+            <Group justify="flex-end">
+              <Button
+                type="submit"
+                disabled={!form.isDirty() || !form.isValid()}
+              >
+                Save
+              </Button>
+            </Group>
+          </Stack>
+        </form>
+      </Card>
+    </Stack>
+  );
+}

--- a/web/src/pages/subscribers/SubscriberForm.tsx
+++ b/web/src/pages/subscribers/SubscriberForm.tsx
@@ -39,7 +39,6 @@ interface SubscriberFormProps {
  * round-trip, and derive `tac` from them on submit.
  */
 interface FormValues {
-  name: string;
   msisdn: string;
   iccid: string;
   manufacturer: string;
@@ -48,7 +47,6 @@ interface FormValues {
 }
 
 const EMPTY: FormValues = {
-  name: '',
   msisdn: '',
   iccid: '',
   manufacturer: '',
@@ -62,7 +60,6 @@ function fromSubscriber(
 ): FormValues {
   const entry = sub.tac ? catalog.find((e) => e.tac === sub.tac) : undefined;
   return {
-    name: sub.name,
     msisdn: sub.msisdn,
     iccid: sub.iccid,
     manufacturer: entry?.manufacturer ?? '',
@@ -100,7 +97,6 @@ export function SubscriberForm({
     initialValues: initial ? fromSubscriber(initial, catalog) : EMPTY,
     validateInputOnChange: true,
     validate: {
-      name: (v) => (v.trim() ? null : 'Name is required'),
       msisdn: (v) =>
         /^[0-9]{8,15}$/.test(v.trim())
           ? null
@@ -175,7 +171,6 @@ export function SubscriberForm({
 
   const handleSubmit = form.onSubmit(async (values) => {
     const input: SubscriberInput = {
-      name: values.name.trim(),
       msisdn: values.msisdn.trim(),
       iccid: values.iccid.trim(),
       tac: pickedTac || undefined,
@@ -227,26 +222,12 @@ export function SubscriberForm({
           {mode === 'edit' ? 'Edit subscriber' : 'Add subscriber'}
         </Text>
         <Title order={3} fw={600}>
-          {mode === 'edit' ? (initial?.name ?? 'Subscriber') : 'New subscriber'}
+          {mode === 'edit' ? (initial?.msisdn ?? 'Subscriber') : 'New subscriber'}
         </Title>
       </Stack>
 
       {/* Scrollable body */}
       <Stack gap="lg" style={{ flex: 1, overflowY: 'auto' }} pr="xs">
-        {/* IDENTITY */}
-        <Stack gap="sm">
-          <SectionLabel>Identity</SectionLabel>
-          <TextInput
-            label="Name"
-            placeholder="Alice Test"
-            required
-            key={form.key('name')}
-            {...form.getInputProps('name')}
-          />
-        </Stack>
-
-        <Divider />
-
         {/* SIM */}
         <Stack gap="sm">
           <SectionLabel>SIM</SectionLabel>

--- a/web/src/pages/subscribers/SubscriberForm.tsx
+++ b/web/src/pages/subscribers/SubscriberForm.tsx
@@ -1,0 +1,396 @@
+import {
+  ActionIcon,
+  Button,
+  Divider,
+  Group,
+  Select,
+  Stack,
+  Text,
+  TextInput,
+  Title,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { IconRefresh } from '@tabler/icons-react';
+import { useEffect, useMemo } from 'react';
+
+import { ApiError } from '../../api/errors';
+import { buildImei, isValidImei } from '../../api/imei';
+import type {
+  Subscriber,
+  SubscriberInput,
+  TacEntry,
+} from '../../api/resources/subscribers';
+
+interface SubscriberFormProps {
+  /** When provided, the form pre-fills with this subscriber's fields (edit mode). */
+  initial?: Subscriber;
+  mode: 'create' | 'edit';
+  submitting?: boolean;
+  deleting?: boolean;
+  catalog: TacEntry[];
+  onSubmit: (values: SubscriberInput) => Promise<Subscriber | void>;
+  onDelete?: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Form values are a superset of `SubscriberInput`: we carry the picked
+ * manufacturer/model as their own keys so the two cascading selects can
+ * round-trip, and derive `tac` from them on submit.
+ */
+interface FormValues {
+  name: string;
+  msisdn: string;
+  iccid: string;
+  manufacturer: string;
+  model: string;
+  imei: string;
+}
+
+const EMPTY: FormValues = {
+  name: '',
+  msisdn: '',
+  iccid: '',
+  manufacturer: '',
+  model: '',
+  imei: '',
+};
+
+function fromSubscriber(
+  sub: Subscriber,
+  catalog: TacEntry[],
+): FormValues {
+  const entry = sub.tac ? catalog.find((e) => e.tac === sub.tac) : undefined;
+  return {
+    name: sub.name,
+    msisdn: sub.msisdn,
+    iccid: sub.iccid,
+    manufacturer: entry?.manufacturer ?? '',
+    model: entry?.model ?? '',
+    imei: sub.imei ?? '',
+  };
+}
+
+/** Small heading like the Peers form. */
+function SectionLabel({ children }: { children: string }) {
+  return (
+    <Text
+      size="xs"
+      fw={600}
+      c="dimmed"
+      tt="uppercase"
+      style={{ letterSpacing: 0.5 }}
+    >
+      {children}
+    </Text>
+  );
+}
+
+export function SubscriberForm({
+  initial,
+  mode,
+  submitting,
+  deleting,
+  catalog,
+  onSubmit,
+  onDelete,
+  onCancel,
+}: SubscriberFormProps) {
+  const form = useForm<FormValues>({
+    initialValues: initial ? fromSubscriber(initial, catalog) : EMPTY,
+    validateInputOnChange: true,
+    validate: {
+      name: (v) => (v.trim() ? null : 'Name is required'),
+      msisdn: (v) =>
+        /^[0-9]{8,15}$/.test(v.trim())
+          ? null
+          : 'MSISDN must be 8–15 digits',
+      iccid: (v) =>
+        /^[0-9]{19,20}$/.test(v.trim())
+          ? null
+          : 'ICCID must be 19 or 20 digits',
+      // Device fields are optional — but if one is set, the other must be
+      // too (so the resulting TAC is unambiguous).
+      manufacturer: (v, values) =>
+        v || !values.model ? null : 'Pick a manufacturer to match the model',
+      model: (v, values) =>
+        v || !values.manufacturer ? null : 'Pick a model to match the manufacturer',
+    },
+  });
+
+  // Reset form whenever we switch which subscriber we're editing.
+  useEffect(() => {
+    form.setValues(initial ? fromSubscriber(initial, catalog) : EMPTY);
+    form.resetDirty();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initial?.id, catalog]);
+
+  // Manufacturer list is just the distinct brands in the catalogue,
+  // alphabetically. Keeping derivation inside the component rather than
+  // a module-level constant so it re-runs if the catalogue changes.
+  const manufacturers = useMemo(() => {
+    const set = new Set<string>();
+    for (const e of catalog) set.add(e.manufacturer);
+    return [...set].sort().map((m) => ({ value: m, label: m }));
+  }, [catalog]);
+
+  const selectedManufacturer = form.getValues().manufacturer;
+  const selectedModel = form.getValues().model;
+
+  const models = useMemo(() => {
+    if (!selectedManufacturer) return [];
+    return catalog
+      .filter((e) => e.manufacturer === selectedManufacturer)
+      .sort((a, b) => (a.year ?? 0) - (b.year ?? 0) || a.model.localeCompare(b.model))
+      .map((e) => ({ value: e.model, label: e.model }));
+  }, [catalog, selectedManufacturer]);
+
+  const pickedTac: string | undefined = useMemo(() => {
+    if (!selectedManufacturer || !selectedModel) return undefined;
+    return catalog.find(
+      (e) =>
+        e.manufacturer === selectedManufacturer && e.model === selectedModel,
+    )?.tac;
+  }, [catalog, selectedManufacturer, selectedModel]);
+
+  // When Manufacturer or Model changes, roll a fresh IMEI (or clear it
+  // if no device is selected). This mirrors the Figma: the IMEI isn't
+  // editable, it's derived from the picked TAC.
+  useEffect(() => {
+    if (!pickedTac) {
+      if (form.getValues().imei) form.setFieldValue('imei', '');
+      return;
+    }
+    const current = form.getValues().imei;
+    if (!current || !current.startsWith(pickedTac) || !isValidImei(current)) {
+      form.setFieldValue('imei', buildImei(pickedTac) ?? '');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pickedTac]);
+
+  const handleRegenerate = () => {
+    if (!pickedTac) return;
+    form.setFieldValue('imei', buildImei(pickedTac) ?? '');
+  };
+
+  const handleSubmit = form.onSubmit(async (values) => {
+    const input: SubscriberInput = {
+      name: values.name.trim(),
+      msisdn: values.msisdn.trim(),
+      iccid: values.iccid.trim(),
+      tac: pickedTac || undefined,
+      imei: pickedTac && values.imei ? values.imei : undefined,
+    };
+    try {
+      await onSubmit(input);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 422) {
+        const fieldErrors = err.fieldErrors();
+        // Map server `/tac` errors back onto the Manufacturer field so
+        // the message lands where the user can act on it. Same story for
+        // `/imei` — there's no visible IMEI editor in validation terms,
+        // so attach it to the Model field.
+        const mapped: Record<string, string> = {};
+        for (const [k, v] of Object.entries(fieldErrors)) {
+          if (k === 'tac') mapped.manufacturer = v;
+          else if (k === 'imei') mapped.model = v;
+          else mapped[k] = v;
+        }
+        if (Object.keys(mapped).length > 0) {
+          form.setErrors(mapped);
+          return;
+        }
+      }
+      throw err;
+    }
+  });
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        flex: 1,
+        minHeight: 0,
+      }}
+    >
+      {/* Header */}
+      <Stack gap={4} pb="md">
+        <Text
+          size="xs"
+          fw={600}
+          c="dimmed"
+          tt="uppercase"
+          style={{ letterSpacing: 0.5 }}
+        >
+          {mode === 'edit' ? 'Edit subscriber' : 'Add subscriber'}
+        </Text>
+        <Title order={3} fw={600}>
+          {mode === 'edit' ? (initial?.name ?? 'Subscriber') : 'New subscriber'}
+        </Title>
+      </Stack>
+
+      {/* Scrollable body */}
+      <Stack gap="lg" style={{ flex: 1, overflowY: 'auto' }} pr="xs">
+        {/* IDENTITY */}
+        <Stack gap="sm">
+          <SectionLabel>Identity</SectionLabel>
+          <TextInput
+            label="Name"
+            placeholder="Alice Test"
+            required
+            key={form.key('name')}
+            {...form.getInputProps('name')}
+          />
+        </Stack>
+
+        <Divider />
+
+        {/* SIM */}
+        <Stack gap="sm">
+          <SectionLabel>SIM</SectionLabel>
+          <TextInput
+            label="MSISDN"
+            placeholder="27821234567"
+            required
+            key={form.key('msisdn')}
+            {...form.getInputProps('msisdn')}
+          />
+          <TextInput
+            label="ICCID"
+            placeholder="89270100001234567890"
+            required
+            key={form.key('iccid')}
+            {...form.getInputProps('iccid')}
+          />
+        </Stack>
+
+        <Divider />
+
+        {/* DEVICE */}
+        <Stack gap="sm">
+          <SectionLabel>Device</SectionLabel>
+          <Group grow align="flex-start">
+            <Select
+              label={
+                <Group gap={6}>
+                  <Text component="span" size="sm" fw={500}>
+                    Manufacturer
+                  </Text>
+                  <Text component="span" size="xs" c="dimmed">
+                    (optional)
+                  </Text>
+                </Group>
+              }
+              placeholder="Select"
+              data={manufacturers}
+              searchable
+              clearable
+              key={form.key('manufacturer')}
+              {...form.getInputProps('manufacturer')}
+              onChange={(v) => {
+                form.setFieldValue('manufacturer', v ?? '');
+                // Switching manufacturer invalidates the model pick.
+                form.setFieldValue('model', '');
+              }}
+            />
+            <Select
+              label={
+                <Group gap={6}>
+                  <Text component="span" size="sm" fw={500}>
+                    Model
+                  </Text>
+                  <Text component="span" size="xs" c="dimmed">
+                    (optional)
+                  </Text>
+                </Group>
+              }
+              placeholder={selectedManufacturer ? 'Select' : '—'}
+              data={models}
+              disabled={!selectedManufacturer}
+              searchable
+              clearable
+              key={form.key('model')}
+              {...form.getInputProps('model')}
+              onChange={(v) => form.setFieldValue('model', v ?? '')}
+            />
+          </Group>
+          <TextInput
+            label={
+              <Group gap={6}>
+                <Text component="span" size="sm" fw={500}>
+                  IMEI
+                </Text>
+                <Text component="span" size="xs" c="dimmed">
+                  (generated)
+                </Text>
+              </Group>
+            }
+            readOnly
+            placeholder="—"
+            value={form.getValues().imei}
+            rightSectionWidth={130}
+            rightSection={
+              pickedTac ? (
+                <Button
+                  variant="subtle"
+                  size="compact-xs"
+                  leftSection={<IconRefresh size={12} />}
+                  onClick={handleRegenerate}
+                >
+                  Regenerate
+                </Button>
+              ) : (
+                <ActionIcon
+                  variant="transparent"
+                  color="gray"
+                  size="sm"
+                  disabled
+                  aria-label="Regenerate IMEI (disabled)"
+                >
+                  <IconRefresh size={14} />
+                </ActionIcon>
+              )
+            }
+            styles={{ input: { backgroundColor: 'var(--mantine-color-gray-0)' } }}
+          />
+        </Stack>
+      </Stack>
+
+      {/* Footer */}
+      <Group
+        justify="space-between"
+        pt="md"
+        mt="md"
+        style={{ borderTop: '1px solid var(--mantine-color-gray-3)' }}
+      >
+        {mode === 'edit' && onDelete ? (
+          <Button
+            variant="subtle"
+            color="red"
+            onClick={onDelete}
+            loading={deleting}
+            disabled={submitting}
+          >
+            Delete
+          </Button>
+        ) : (
+          <span />
+        )}
+        <Group gap="xs">
+          <Button variant="default" onClick={onCancel} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            loading={submitting}
+            disabled={!form.isValid() || deleting}
+          >
+            {mode === 'edit' ? 'Update' : 'Create'}
+          </Button>
+        </Group>
+      </Group>
+    </form>
+  );
+}

--- a/web/src/pages/subscribers/SubscriberForm.tsx
+++ b/web/src/pages/subscribers/SubscriberForm.tsx
@@ -14,12 +14,14 @@ import { IconRefresh } from '@tabler/icons-react';
 import { useEffect, useMemo } from 'react';
 
 import { ApiError } from '../../api/errors';
+import { buildIccid } from '../../api/iccid';
 import { buildImei, isValidImei } from '../../api/imei';
 import type {
   Subscriber,
   SubscriberInput,
   TacEntry,
 } from '../../api/resources/subscribers';
+import { isValidMccmnc, useSettings } from '../../settings/settings';
 
 interface SubscriberFormProps {
   /** When provided, the form pre-fills with this subscriber's fields (edit mode). */
@@ -93,6 +95,7 @@ export function SubscriberForm({
   onDelete,
   onCancel,
 }: SubscriberFormProps) {
+  const settings = useSettings();
   const form = useForm<FormValues>({
     initialValues: initial ? fromSubscriber(initial, catalog) : EMPTY,
     validateInputOnChange: true,
@@ -244,6 +247,32 @@ export function SubscriberForm({
             required
             key={form.key('iccid')}
             {...form.getInputProps('iccid')}
+            rightSectionWidth={110}
+            rightSection={
+              isValidMccmnc(settings.mccmnc) ? (
+                <Button
+                  variant="subtle"
+                  size="compact-xs"
+                  leftSection={<IconRefresh size={12} />}
+                  onClick={() => {
+                    const next = buildIccid(settings.mccmnc);
+                    if (next) form.setFieldValue('iccid', next);
+                  }}
+                >
+                  Generate
+                </Button>
+              ) : (
+                <ActionIcon
+                  variant="transparent"
+                  color="gray"
+                  size="sm"
+                  disabled
+                  aria-label="Generate ICCID (set MCCMNC in Settings)"
+                >
+                  <IconRefresh size={14} />
+                </ActionIcon>
+              )
+            }
           />
         </Stack>
 

--- a/web/src/pages/subscribers/SubscribersPage.tsx
+++ b/web/src/pages/subscribers/SubscribersPage.tsx
@@ -1,0 +1,473 @@
+import {
+  ActionIcon,
+  Alert,
+  Button,
+  Card,
+  Drawer,
+  Group,
+  Menu,
+  Modal,
+  Skeleton,
+  Stack,
+  Table,
+  Text,
+  TextInput,
+  Title,
+} from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import {
+  IconAlertTriangle,
+  IconDots,
+  IconPencil,
+  IconPlus,
+  IconSearch,
+} from '@tabler/icons-react';
+import { useMemo, useState } from 'react';
+
+import { ApiError } from '../../api/errors';
+import type {
+  Subscriber,
+  SubscriberInput,
+  TacEntry,
+} from '../../api/resources/subscribers';
+import {
+  useCreateSubscriber,
+  useDeleteSubscriber,
+  useSubscribers,
+  useTacCatalog,
+  useUpdateSubscriber,
+} from '../../api/resources/subscribers';
+import { SubscriberForm } from './SubscriberForm';
+
+/**
+ * Drawer styles — same pattern as Peers (flex column with its own
+ * scrollable body and sticky footer). Kept as a module-level const so
+ * both drawers reuse the same shape.
+ */
+const DRAWER_STYLES = {
+  content: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+  },
+  body: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    flex: 1,
+    minHeight: 0,
+    overflow: 'hidden',
+  },
+};
+
+/**
+ * Subscribers listing. Matches the Figma "Subscribers / Light" and
+ * "Subscribers - Edit / Light" screens. Mirrors the Peers CRUD pattern:
+ * search, table, kebab-to-edit, right-hand drawer, delete-via-drawer.
+ *
+ * No status filter and no lifecycle actions — a Subscriber is pure
+ * configuration with no runtime state.
+ */
+export function SubscribersPage() {
+  const subs = useSubscribers();
+  const catalog = useTacCatalog();
+  const [query, setQuery] = useState('');
+  const [drawer, setDrawer] = useState<
+    { kind: 'closed' } | { kind: 'create' } | { kind: 'edit'; sub: Subscriber }
+  >({ kind: 'closed' });
+  const [deleteTarget, setDeleteTarget] = useState<Subscriber | undefined>();
+
+  const filtered = useMemo(() => {
+    if (!subs.data) return [];
+    const q = query.trim().toLowerCase();
+    if (!q) return subs.data;
+    return subs.data.filter(
+      (s) =>
+        s.name.toLowerCase().includes(q) ||
+        s.msisdn.toLowerCase().includes(q) ||
+        s.iccid.toLowerCase().includes(q) ||
+        (s.imei ?? '').toLowerCase().includes(q),
+    );
+  }, [subs.data, query]);
+
+  return (
+    <Stack gap="lg" p="md">
+      <Group justify="space-between" align="flex-start" wrap="nowrap">
+        <Stack gap={4}>
+          <Title order={2} fw={600}>
+            Subscribers
+          </Title>
+          <Text c="dimmed" size="sm">
+            Manage subscriber identities (MSISDN, ICCID, IMEI).
+          </Text>
+        </Stack>
+        <Button
+          leftSection={<IconPlus size={16} />}
+          onClick={() => setDrawer({ kind: 'create' })}
+        >
+          Add subscriber
+        </Button>
+      </Group>
+
+      <Group>
+        <TextInput
+          placeholder="Search by MSISDN, ICCID, IMEI…"
+          value={query}
+          onChange={(e) => setQuery(e.currentTarget.value)}
+          leftSection={<IconSearch size={14} />}
+          w={320}
+          aria-label="Search subscribers"
+        />
+      </Group>
+
+      {subs.isError ? (
+        <Alert
+          color="red"
+          icon={<IconAlertTriangle size={18} />}
+          title="Subscribers unavailable"
+          variant="light"
+        >
+          <Stack gap="xs" align="flex-start">
+            <Text size="sm" c="dimmed">
+              Couldn&apos;t load subscribers. Check the API and try again.
+            </Text>
+            <Button
+              size="xs"
+              variant="subtle"
+              color="red"
+              onClick={() => subs.refetch()}
+            >
+              Retry
+            </Button>
+          </Stack>
+        </Alert>
+      ) : subs.isLoading || !subs.data ? (
+        <Card padding="lg" withBorder shadow="xs">
+          <Stack gap="sm">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} h={40} radius="sm" />
+            ))}
+          </Stack>
+        </Card>
+      ) : (
+        <Card padding={0} withBorder shadow="xs">
+          <Table highlightOnHover verticalSpacing="sm" horizontalSpacing="md">
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th tt="uppercase" fz="xs" c="dimmed">Name</Table.Th>
+                <Table.Th tt="uppercase" fz="xs" c="dimmed">MSISDN</Table.Th>
+                <Table.Th tt="uppercase" fz="xs" c="dimmed">ICCID</Table.Th>
+                <Table.Th tt="uppercase" fz="xs" c="dimmed">IMEI</Table.Th>
+                <Table.Th tt="uppercase" fz="xs" c="dimmed">Device</Table.Th>
+                <Table.Th w={48} aria-label="Actions" />
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {filtered.length === 0 ? (
+                <Table.Tr>
+                  <Table.Td colSpan={6}>
+                    <Text c="dimmed" ta="center" py="md" size="sm">
+                      {subs.data.length === 0
+                        ? 'No subscribers yet. Click Add subscriber to create one.'
+                        : 'No subscribers match the current filters.'}
+                    </Text>
+                  </Table.Td>
+                </Table.Tr>
+              ) : (
+                filtered.map((sub) => (
+                  <SubscriberRow
+                    key={sub.id}
+                    sub={sub}
+                    catalog={catalog.data ?? []}
+                    onEdit={() => setDrawer({ kind: 'edit', sub })}
+                  />
+                ))
+              )}
+            </Table.Tbody>
+          </Table>
+        </Card>
+      )}
+
+      <CreateSubscriberDrawer
+        open={drawer.kind === 'create'}
+        catalog={catalog.data ?? []}
+        onClose={() => setDrawer({ kind: 'closed' })}
+      />
+      <EditSubscriberDrawer
+        sub={drawer.kind === 'edit' ? drawer.sub : undefined}
+        catalog={catalog.data ?? []}
+        onClose={() => setDrawer({ kind: 'closed' })}
+        onRequestDelete={(s) => {
+          setDrawer({ kind: 'closed' });
+          setDeleteTarget(s);
+        }}
+      />
+      <DeleteSubscriberModal
+        sub={deleteTarget}
+        onClose={() => setDeleteTarget(undefined)}
+      />
+    </Stack>
+  );
+}
+
+/**
+ * One row in the subscribers table. Resolves the TAC → manufacturer/
+ * model display string from the catalogue so the "Device" column
+ * matches what the edit drawer shows.
+ */
+function SubscriberRow({
+  sub,
+  catalog,
+  onEdit,
+}: {
+  sub: Subscriber;
+  catalog: TacEntry[];
+  onEdit: () => void;
+}) {
+  const device = sub.tac
+    ? catalog.find((e) => e.tac === sub.tac)?.model ?? `TAC ${sub.tac}`
+    : '—';
+  return (
+    <Table.Tr>
+      <Table.Td>
+        <Text size="sm" fw={600}>
+          {sub.name}
+        </Text>
+      </Table.Td>
+      <Table.Td>
+        <Text size="sm" ff="monospace">
+          {sub.msisdn}
+        </Text>
+      </Table.Td>
+      <Table.Td>
+        <Text size="sm" ff="monospace">
+          {sub.iccid}
+        </Text>
+      </Table.Td>
+      <Table.Td>
+        <Text size="sm" ff="monospace" c={sub.imei ? undefined : 'dimmed'}>
+          {sub.imei ?? '—'}
+        </Text>
+      </Table.Td>
+      <Table.Td>
+        <Text size="sm" c={sub.tac ? undefined : 'dimmed'}>
+          {device}
+        </Text>
+      </Table.Td>
+      <Table.Td>
+        <Menu shadow="md" width={160} position="bottom-end">
+          <Menu.Target>
+            <ActionIcon
+              variant="subtle"
+              color="gray"
+              aria-label={`Actions for ${sub.name}`}
+            >
+              <IconDots size={16} />
+            </ActionIcon>
+          </Menu.Target>
+          <Menu.Dropdown>
+            <Menu.Item leftSection={<IconPencil size={14} />} onClick={onEdit}>
+              Edit
+            </Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
+      </Table.Td>
+    </Table.Tr>
+  );
+}
+
+function CreateSubscriberDrawer({
+  open,
+  catalog,
+  onClose,
+}: {
+  open: boolean;
+  catalog: TacEntry[];
+  onClose: () => void;
+}) {
+  const createSub = useCreateSubscriber();
+
+  const handleSubmit = async (values: SubscriberInput) => {
+    try {
+      const created = await createSub.mutateAsync(values);
+      notifications.show({
+        color: 'teal',
+        title: 'Subscriber created',
+        message: `${created.name} is ready.`,
+      });
+      onClose();
+      return created;
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 422) throw err;
+      notifications.show({
+        color: 'red',
+        title: 'Could not create subscriber',
+        message: err instanceof Error ? err.message : 'Unexpected error',
+      });
+      throw err;
+    }
+  };
+
+  return (
+    <Drawer
+      opened={open}
+      onClose={onClose}
+      position="right"
+      size={480}
+      padding="lg"
+      withCloseButton
+      closeOnClickOutside={!createSub.isPending}
+      closeOnEscape={!createSub.isPending}
+      styles={DRAWER_STYLES}
+    >
+      <SubscriberForm
+        mode="create"
+        catalog={catalog}
+        submitting={createSub.isPending}
+        onSubmit={handleSubmit}
+        onCancel={onClose}
+      />
+    </Drawer>
+  );
+}
+
+function EditSubscriberDrawer({
+  sub,
+  catalog,
+  onClose,
+  onRequestDelete,
+}: {
+  sub: Subscriber | undefined;
+  catalog: TacEntry[];
+  onClose: () => void;
+  onRequestDelete: (s: Subscriber) => void;
+}) {
+  return (
+    <Drawer
+      opened={Boolean(sub)}
+      onClose={onClose}
+      position="right"
+      size={480}
+      padding="lg"
+      withCloseButton
+      styles={DRAWER_STYLES}
+    >
+      {sub && (
+        <EditSubscriberForm
+          sub={sub}
+          catalog={catalog}
+          onClose={onClose}
+          onRequestDelete={() => onRequestDelete(sub)}
+        />
+      )}
+    </Drawer>
+  );
+}
+
+function EditSubscriberForm({
+  sub,
+  catalog,
+  onClose,
+  onRequestDelete,
+}: {
+  sub: Subscriber;
+  catalog: TacEntry[];
+  onClose: () => void;
+  onRequestDelete: () => void;
+}) {
+  const updateSub = useUpdateSubscriber(sub.id);
+
+  const handleSubmit = async (values: SubscriberInput) => {
+    try {
+      const next = await updateSub.mutateAsync(values);
+      notifications.show({
+        color: 'teal',
+        title: 'Subscriber updated',
+        message: `${next.name} was saved.`,
+      });
+      onClose();
+      return next;
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 422) throw err;
+      notifications.show({
+        color: 'red',
+        title: 'Could not update subscriber',
+        message: err instanceof Error ? err.message : 'Unexpected error',
+      });
+      throw err;
+    }
+  };
+
+  return (
+    <SubscriberForm
+      mode="edit"
+      initial={sub}
+      catalog={catalog}
+      submitting={updateSub.isPending}
+      onSubmit={handleSubmit}
+      onDelete={onRequestDelete}
+      onCancel={onClose}
+    />
+  );
+}
+
+function DeleteSubscriberModal({
+  sub,
+  onClose,
+}: {
+  sub: Subscriber | undefined;
+  onClose: () => void;
+}) {
+  const deleteSub = useDeleteSubscriber();
+
+  const handleConfirm = async () => {
+    if (!sub) return;
+    try {
+      await deleteSub.mutateAsync(sub.id);
+      notifications.show({
+        color: 'teal',
+        title: 'Subscriber deleted',
+        message: `${sub.name} was removed.`,
+      });
+      onClose();
+    } catch (err) {
+      notifications.show({
+        color: 'red',
+        title: 'Could not delete subscriber',
+        message: err instanceof Error ? err.message : 'Unexpected error',
+      });
+    }
+  };
+
+  return (
+    <Modal
+      opened={Boolean(sub)}
+      onClose={onClose}
+      title="Delete subscriber"
+      centered
+      closeOnClickOutside={!deleteSub.isPending}
+      closeOnEscape={!deleteSub.isPending}
+    >
+      <Stack gap="md">
+        <Text size="sm">
+          Are you sure you want to delete{' '}
+          <strong>{sub?.name ?? ''}</strong>? This cannot be undone.
+        </Text>
+        <Group justify="flex-end">
+          <Button
+            variant="subtle"
+            onClick={onClose}
+            disabled={deleteSub.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            color="red"
+            loading={deleteSub.isPending}
+            onClick={handleConfirm}
+          >
+            Delete
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/web/src/pages/subscribers/SubscribersPage.tsx
+++ b/web/src/pages/subscribers/SubscribersPage.tsx
@@ -81,7 +81,6 @@ export function SubscribersPage() {
     if (!q) return subs.data;
     return subs.data.filter(
       (s) =>
-        s.name.toLowerCase().includes(q) ||
         s.msisdn.toLowerCase().includes(q) ||
         s.iccid.toLowerCase().includes(q) ||
         (s.imei ?? '').toLowerCase().includes(q),
@@ -152,7 +151,6 @@ export function SubscribersPage() {
           <Table highlightOnHover verticalSpacing="sm" horizontalSpacing="md">
             <Table.Thead>
               <Table.Tr>
-                <Table.Th tt="uppercase" fz="xs" c="dimmed">Name</Table.Th>
                 <Table.Th tt="uppercase" fz="xs" c="dimmed">MSISDN</Table.Th>
                 <Table.Th tt="uppercase" fz="xs" c="dimmed">ICCID</Table.Th>
                 <Table.Th tt="uppercase" fz="xs" c="dimmed">IMEI</Table.Th>
@@ -163,7 +161,7 @@ export function SubscribersPage() {
             <Table.Tbody>
               {filtered.length === 0 ? (
                 <Table.Tr>
-                  <Table.Td colSpan={6}>
+                  <Table.Td colSpan={5}>
                     <Text c="dimmed" ta="center" py="md" size="sm">
                       {subs.data.length === 0
                         ? 'No subscribers yet. Click Add subscriber to create one.'
@@ -228,12 +226,7 @@ function SubscriberRow({
   return (
     <Table.Tr>
       <Table.Td>
-        <Text size="sm" fw={600}>
-          {sub.name}
-        </Text>
-      </Table.Td>
-      <Table.Td>
-        <Text size="sm" ff="monospace">
+        <Text size="sm" ff="monospace" fw={600}>
           {sub.msisdn}
         </Text>
       </Table.Td>
@@ -258,7 +251,7 @@ function SubscriberRow({
             <ActionIcon
               variant="subtle"
               color="gray"
-              aria-label={`Actions for ${sub.name}`}
+              aria-label={`Actions for ${sub.msisdn}`}
             >
               <IconDots size={16} />
             </ActionIcon>
@@ -291,7 +284,7 @@ function CreateSubscriberDrawer({
       notifications.show({
         color: 'teal',
         title: 'Subscriber created',
-        message: `${created.name} is ready.`,
+        message: `${created.msisdn} is ready.`,
       });
       onClose();
       return created;
@@ -381,7 +374,7 @@ function EditSubscriberForm({
       notifications.show({
         color: 'teal',
         title: 'Subscriber updated',
-        message: `${next.name} was saved.`,
+        message: `${next.msisdn} was saved.`,
       });
       onClose();
       return next;
@@ -425,7 +418,7 @@ function DeleteSubscriberModal({
       notifications.show({
         color: 'teal',
         title: 'Subscriber deleted',
-        message: `${sub.name} was removed.`,
+        message: `${sub.msisdn} was removed.`,
       });
       onClose();
     } catch (err) {
@@ -448,8 +441,8 @@ function DeleteSubscriberModal({
     >
       <Stack gap="md">
         <Text size="sm">
-          Are you sure you want to delete{' '}
-          <strong>{sub?.name ?? ''}</strong>? This cannot be undone.
+          Are you sure you want to delete subscriber{' '}
+          <strong>{sub?.msisdn ?? ''}</strong>? This cannot be undone.
         </Text>
         <Group justify="flex-end">
           <Button

--- a/web/src/settings/settings.ts
+++ b/web/src/settings/settings.ts
@@ -1,0 +1,76 @@
+/**
+ * Client-side settings. Persisted to `localStorage` so a reload keeps
+ * your preferences. Kept client-side for now — if any of these values
+ * ever need to be shared across machines we'd push them server-side
+ * via a `/settings` endpoint; none of them do today.
+ */
+
+import { useSyncExternalStore } from 'react';
+
+export interface Settings {
+  /**
+   * Mobile Country Code + Mobile Network Code used when generating an
+   * ICCID. 5 digits (3-digit MCC + 2-digit MNC, e.g. "65510" for MTN
+   * South Africa) or 6 digits (3 + 3, e.g. "310410" for AT&T Wireless).
+   */
+  mccmnc: string;
+}
+
+// "655 10" is MTN South Africa — a plausible default for the testbench.
+// Chosen because the Figma fixtures use South African MSISDNs (27…).
+const DEFAULT_SETTINGS: Settings = {
+  mccmnc: '65510',
+};
+
+const STORAGE_KEY = 'ocs.settings.v1';
+
+function read(): Settings {
+  if (typeof localStorage === 'undefined') return DEFAULT_SETTINGS;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_SETTINGS;
+    const parsed = JSON.parse(raw) as Partial<Settings>;
+    return { ...DEFAULT_SETTINGS, ...parsed };
+  } catch {
+    return DEFAULT_SETTINGS;
+  }
+}
+
+let cached: Settings = read();
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const l of listeners) l();
+}
+
+export function getSettings(): Settings {
+  return cached;
+}
+
+export function setSettings(next: Partial<Settings>): void {
+  cached = { ...cached, ...next };
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(cached));
+  } catch {
+    // localStorage may be unavailable (private mode, quota) — keep the
+    // in-memory copy so the UI still reflects the change this session.
+  }
+  emit();
+}
+
+function subscribe(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
+}
+
+/** React hook — re-renders when any setting changes. */
+export function useSettings(): Settings {
+  return useSyncExternalStore(subscribe, getSettings, getSettings);
+}
+
+/** MCCMNC is valid when it's 5 or 6 digits. */
+export function isValidMccmnc(mccmnc: string): boolean {
+  return /^[0-9]{5,6}$/.test(mccmnc);
+}

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -10,6 +10,7 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,


### PR DESCRIPTION
## Summary
- Full Subscribers CRUD matching the Figma screen, using Peers as the UX template (right drawer + sticky footer + kebab-to-edit).
- TAC catalogue sourced as a one-time extraction from the [osmocom TAC DB](http://tacdb.osmocom.org) (CC-BY-SA v3.0, Harald Welte) committed as a snapshot JSON, plus a re-runnable extractor script. 33 entries covering the last ~10 years of handsets.
- Cascading Manufacturer → Model → IMEI form; IMEI auto-rolls a Luhn-valid 15-digit number from the selected TAC with a Regenerate button.
- Fake API enforces the same 422 contract the real backend will (format patterns, MSISDN/ICCID uniqueness, TAC-in-catalogue, IMEI Luhn + TAC-prefix consistency).

## Test plan
- [ ] `npm run build` passes (tsc + vite)
- [ ] `npm run lint` clean
- [ ] Open /subscribers — 5 fixtures render, Charlie and Eve show "—" for device
- [ ] Create a subscriber: pick manufacturer → model cascades → IMEI appears; Regenerate rolls a new IMEI; submit saves
- [ ] Edit an existing subscriber with a device: form pre-fills manufacturer + model + IMEI
- [ ] Enter duplicate MSISDN → 422 lands on the MSISDN field
- [ ] Clear both device fields → record saves with no TAC/IMEI

🤖 Generated with [Claude Code](https://claude.com/claude-code)