### PR TITLE
chore: make AGENTS.md bootstrap rule proactive — auto-mount

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,13 +5,35 @@
 
 ## Bootstrap Rule
 
-If the .ai/ directory does not exist, stop immediately.
+The agentic framework lives under `.ai/` and is managed by `gh agentic mount`.
+The directory is gitignored — every fresh clone, worktree, or CI checkout
+starts without it. Mounting is therefore **step zero of every session**, before
+any other initialisation.
 
-- **Interactive context:** Instruct the user to run:
-  `gh agentic mount`
+### Procedure
 
-- **CI context:** Fail with the message:
-  "Framework not mounted. Add a mount step before the pipeline:
-  `gh agentic mount`"
+Run these checks at session start, in order, **before** invoking `session-init`:
 
-Do not proceed with any other work until the framework is mounted.
+1. **Mount is missing.** If `.ai/` does not exist, run `gh agentic mount`
+   and proceed. Do not ask — mounting is idempotent and side-effect-free.
+
+2. **Mount is stale.** If `.ai/` exists, run `gh agentic info` and compare
+   the reported `Framework (local)` version against the repo variable
+   `AGENTIC_FRAMEWORK_VERSION` (if set). If they differ, run
+   `gh agentic mount <AGENTIC_FRAMEWORK_VERSION>` to sync, then proceed.
+
+3. **Mount step failed.** Only in this case halt and report:
+   - **Interactive context:** surface the exact error from `gh agentic mount`
+     and ask the human to resolve.
+   - **CI context:** fail the job with the same error and the message
+     `"Framework mount failed — add a mount step before the pipeline."`
+
+4. **Mount is healthy.** Invoke `session-init` as defined in `.ai/skills/session-init.md`.
+
+### Why this is proactive
+
+A missing or stale mount is the single most common cause of session confusion
+(wrong skills loaded, stale RULEBOOK, broken workflow references). It is
+cheap to detect, cheap to fix, and never destructive — so the agent mounts
+automatically rather than stopping to ask. The only time the agent halts is
+when the mount step itself returns a non-zero exit code.


### PR DESCRIPTION
## Summary

Change the AGENTS.md Bootstrap Rule from \"stop and ask\" to \"just mount\".

- **Missing \`.ai/\`** → run \`gh agentic mount\` automatically, proceed.
- **Stale \`.ai/\`** (local version ≠ \`AGENTIC_FRAMEWORK_VERSION\`) → run \`gh agentic mount <version>\` to sync, proceed.
- **Only halt if the mount step itself fails.**

## Why

A missing or stale mount is the single most common cause of session confusion — wrong skills loaded, stale RULEBOOK, broken workflow references. It just bit us: a worktree started without a fresh mount, which contributed to most of a session being spent reconstructing state that \`gh agentic mount\` would have produced in seconds.

Mounting is idempotent and side-effect-free, so the correct default is to do it, not to ask. The rule now reflects that.

## Test plan

- [ ] Read the updated Bootstrap Rule in AGENTS.md
- [ ] On next fresh worktree / clone, confirm the agent mounts automatically rather than prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)