### PR TITLE
bump(workflows): update reusable workflows to v2.2.5

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   pipeline:
-    uses: eddiecarpenter/gh-agentic/.github/workflows/agentic-pipeline-reusable.yml@v2.2.4
+    uses: eddiecarpenter/gh-agentic/.github/workflows/agentic-pipeline-reusable.yml@v2.2.5
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    uses: eddiecarpenter/gh-agentic/.github/workflows/release-reusable.yml@v2.2.4
+    uses: eddiecarpenter/gh-agentic/.github/workflows/release-reusable.yml@v2.2.5
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Upgrade agentic framework from v2.2.4 to v2.2.5 via `gh agentic upgrade v2.2.5`
- Updates reusable workflow refs in `agentic-pipeline.yml` and `release.yml` to `@v2.2.5`

## Test plan

- [ ] Confirm pipeline fires correctly on next triggering event using the v2.2.5 reusable workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)