### PR TITLE
update(workflows): replace reusable workflow references with direct f…

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -22,7 +22,10 @@ on:
 
 jobs:
   pipeline:
-    uses: eddiecarpenter/gh-agentic/.github/workflows/agentic-pipeline-reusable.yml@v2.2.5
+    uses: eddiecarpenter/gh-agentic/.github/workflows/agentic-pipeline.yml@v2.2.5
+    with:
+      pr_number: ${{ inputs.pr_number || '' }}
+      branch_name: ${{ inputs.branch_name || '' }}
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    uses: eddiecarpenter/gh-agentic/.github/workflows/release-reusable.yml@v2.2.5
+    uses: eddiecarpenter/gh-agentic/.github/workflows/release.yml@v2.2.5
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
…ile paths

Switch `.github/workflows/release.yml` and `.github/workflows/agentic-pipeline.yml` to use direct workflow file paths instead of reusable workflow references, maintaining compatibility and adding new input parameters in `agentic-pipeline.yml`.