### PR TITLE
chore(workflows): upgrade reusable workflow refs to v2.5.4

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   pipeline:
-    uses: eddiecarpenter/gh-agentic/.github/workflows/agentic-pipeline.yml@v2.5.3
+    uses: eddiecarpenter/gh-agentic/.github/workflows/agentic-pipeline.yml@v2.5.4
     with:
       pr_number: ${{ inputs.pr_number || '' }}
       branch_name: ${{ inputs.branch_name || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    uses: eddiecarpenter/gh-agentic/.github/workflows/release.yml@v2.5.3
+    uses: eddiecarpenter/gh-agentic/.github/workflows/release.yml@v2.5.4
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Bump the reusable workflow refs from `@v2.5.3` to `@v2.5.4`. v2.5.4 fixes the `.agentic-tools` dependency that was breaking Stage 4 (Dev Session) checkouts — see #88 for the symptom and the run history on issue #77 for the failures.

## Changes

- \`.github/workflows/agentic-pipeline.yml\` — \`@v2.5.3\` → \`@v2.5.4\`
- \`.github/workflows/release.yml\` — \`@v2.5.3\` → \`@v2.5.4\`

Performed via \`gh agentic upgrade v2.5.4\`. The repo variable \`AGENTIC_FRAMEWORK_VERSION\` is already updated to \`v2.5.4\` by the same command.

## Test plan

- [ ] PR's own CI checks pass
- [ ] After merge, retrigger the agentic pipeline against #77 (toggle \`in-development\`) and confirm the Dev Session reaches its intended work