### PR TITLE
chore(dev): single-port dev mode via Go-side reverse proxy to Vite

### DIFF
--- a/cmd/ocs-testbench/devmode.go
+++ b/cmd/ocs-testbench/devmode.go
@@ -1,0 +1,21 @@
+//go:build !dev
+
+package main
+
+import (
+	"io/fs"
+	"net/http"
+)
+
+// devFrontendHandler is the dev-mode hook into runWith. The non-dev
+// build returns (nil, nil), telling runWith to fall through to the
+// embedded-FS handler. The corresponding `//go:build dev` file in
+// devmode_dev.go returns a real handler (a Vite reverse proxy) and
+// registers the supervisor's Stop on lifecycle shutdown.
+//
+// The signature is identical in both builds so runWith stays
+// build-tag agnostic. The shutdownRegistrar interface lives in
+// devmode_iface.go so both builds can reference it.
+func devFrontendHandler(_ shutdownRegistrar, _ fs.FS) (http.Handler, error) {
+	return nil, nil
+}

--- a/cmd/ocs-testbench/devmode_dev.go
+++ b/cmd/ocs-testbench/devmode_dev.go
@@ -1,0 +1,38 @@
+//go:build dev
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"time"
+
+	"github.com/eddiecarpenter/ocs-testbench/internal/appl"
+)
+
+// Hard-coded for the noodle. If we ever want to flex these (different
+// port, different working dir for monorepo cousins), promote to
+// config.yaml or env vars. Today the dev workflow is one shape.
+const (
+	viteAddr        = "http://localhost:5173"
+	viteWorkDir     = "web"
+	viteStartupWait = 30 * time.Second
+)
+
+// devFrontendHandler — dev build. Spawns / attaches to a Vite dev
+// server, returns a reverse-proxy handler aimed at it, and registers
+// the supervisor's Stop as a shutdown callback so Vite dies cleanly
+// when the Go process gets SIGTERM. The embedded `_dist` is unused
+// in dev mode (Vite serves the SPA live from source).
+func devFrontendHandler(lc shutdownRegistrar, _ fs.FS) (http.Handler, error) {
+	sup := appl.NewViteSupervisor(viteWorkDir, viteAddr)
+	if err := sup.Start(viteStartupWait); err != nil {
+		return nil, fmt.Errorf("dev: vite supervisor: %w", err)
+	}
+	lc.RegisterShutdown("vite", func(_ context.Context) error {
+		return sup.Stop()
+	})
+	return appl.DevFrontendHandler(viteAddr)
+}

--- a/cmd/ocs-testbench/devmode_iface.go
+++ b/cmd/ocs-testbench/devmode_iface.go
@@ -1,0 +1,17 @@
+// Common interface shared by the build-tag pair `devmode.go`
+// (`!dev`) and `devmode_dev.go` (`dev`). Lives in its own file with
+// no build tag so both builds can reference it.
+//
+// The interface is the slice of `appl.Lifecycle` that the dev hook
+// needs (subprocess-shutdown registration). Defined locally instead
+// of imported from `internal/appl` to keep this package's import
+// graph identical between builds — neither flavour reaches into
+// `appl` from devmode.go's signature.
+
+package main
+
+import "context"
+
+type shutdownRegistrar interface {
+	RegisterShutdown(name string, fn func(context.Context) error)
+}

--- a/cmd/ocs-testbench/main.go
+++ b/cmd/ocs-testbench/main.go
@@ -143,9 +143,20 @@ func runWith(ctx context.Context, cfg *baseconfig.Config, s store.Store, embedde
 	if err != nil {
 		return fmt.Errorf("ocs-testbench: resolve embedded frontend: %w", err)
 	}
-	frontHandler, err := appl.FrontendHandler(dist)
+
+	// Dev mode (only compiled with `-tags dev`) returns a reverse-proxy
+	// handler aimed at a Vite dev server, and registers Vite's lifecycle
+	// on `lc`. In prod builds devFrontendHandler returns (nil, nil) and
+	// the embedded FS path runs.
+	frontHandler, err := devFrontendHandler(lc, dist)
 	if err != nil {
-		return fmt.Errorf("ocs-testbench: frontend handler: %w", err)
+		return fmt.Errorf("ocs-testbench: dev frontend: %w", err)
+	}
+	if frontHandler == nil {
+		frontHandler, err = appl.FrontendHandler(dist)
+		if err != nil {
+			return fmt.Errorf("ocs-testbench: frontend handler: %w", err)
+		}
 	}
 
 	router := chi.NewRouter()

--- a/cmd/ocs-testbench/main_test.go
+++ b/cmd/ocs-testbench/main_test.go
@@ -1,3 +1,12 @@
+// `runWith` is a bootstrap test that walks the full lifecycle on a
+// fake store + fake embedded FS. Under `-tags dev`, runWith spawns
+// a Vite subprocess via the dev frontend hook — that's intentional
+// for the runtime path but breaks tests (no npm or web/ dir context
+// to spawn from). Tag this file `!dev` so the dev-mode build skips
+// it; the prod build (default `go test`) keeps full coverage.
+//
+//go:build !dev
+
 package main
 
 import (

--- a/internal/appl/frontend_dev.go
+++ b/internal/appl/frontend_dev.go
@@ -1,0 +1,243 @@
+//go:build dev
+
+// Dev-only frontend handler — reverse-proxies non-API requests to a
+// running Vite dev server so HMR works through the Go process's port.
+// Compiled in only with `-tags dev`; production builds never link this
+// file (the prod path stays in frontend.go, serving the embedded FS).
+//
+// Layout:
+//   - DevFrontendHandler — the http.Handler that proxies to Vite. Plug
+//     into chi's NotFound the same way prod plugs in FrontendHandler.
+//   - ViteSupervisor    — optional subprocess manager. Tries to detect
+//     an already-running Vite first; spawns `npm run dev` if none is
+//     reachable. Stop() kills the spawned process group on shutdown.
+//
+// The supervisor and the handler are independent — the handler only
+// needs the address of a reachable Vite. Callers that prefer to manage
+// Vite externally (two-terminal flow) can skip the supervisor and use
+// just the handler.
+
+package appl
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// DevFrontendHandler reverse-proxies all incoming requests to a Vite
+// dev server at viteAddr. WebSocket upgrade for HMR is transparent —
+// httputil.ReverseProxy honours `Connection: Upgrade` since Go 1.12.
+//
+// `viteAddr` should be an absolute URL, e.g. `http://localhost:5173`.
+// The Go router's NotFound mount means API routes registered earlier
+// take precedence; everything else falls through to this handler and
+// gets proxied to Vite, which serves the SPA + HMR.
+func DevFrontendHandler(viteAddr string) (http.Handler, error) {
+	target, err := url.Parse(viteAddr)
+	if err != nil {
+		return nil, fmt.Errorf("appl: parse vite addr %q: %w", viteAddr, err)
+	}
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	// Quieter error reporting — Vite occasionally drops the HMR socket
+	// during restarts; the default `log` output is noisy and panics in
+	// tests. Surface as a structured warning instead.
+	proxy.ErrorHandler = func(w http.ResponseWriter, _ *http.Request, err error) {
+		slog.Warn("dev frontend proxy error", "err", err)
+		w.WriteHeader(http.StatusBadGateway)
+	}
+	return proxy, nil
+}
+
+// ViteSupervisor manages a child Vite dev server.
+//
+// Behaviour:
+//   - On Start: probes viteAddr; if Vite is already running, attaches
+//     to it without spawning a child. This lets the developer keep
+//     `npm run dev` open in another terminal and have the Go process
+//     reuse it.
+//   - If no Vite responds: spawns `npm run dev -- --port <port>` from
+//     workDir, with stdout/stderr piped through a `[vite]` prefix so
+//     the operator can tell which logs come from where.
+//   - Polls the address until reachable (timeout default 30s).
+//   - Stop forwards SIGTERM to the entire process group so npm's
+//     descendants (Vite, esbuild, postcss watchers) die too.
+type ViteSupervisor struct {
+	addr    string
+	workDir string
+
+	mu      sync.Mutex
+	cmd     *exec.Cmd
+	spawned bool
+}
+
+// NewViteSupervisor returns a supervisor; nothing is spawned yet.
+// Call Start to attach or spawn.
+func NewViteSupervisor(workDir, viteAddr string) *ViteSupervisor {
+	return &ViteSupervisor{addr: viteAddr, workDir: workDir}
+}
+
+// Start attaches to a running Vite or spawns a new one. Returns nil
+// when Vite is reachable on viteAddr; returns an error if spawn fails
+// or the address never becomes reachable within the timeout.
+func (s *ViteSupervisor) Start(timeout time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if reachable(s.addr, 250*time.Millisecond) {
+		slog.Info("dev: vite already running, reusing", "addr", s.addr)
+		return nil
+	}
+
+	port := portFromAddr(s.addr)
+	slog.Info("dev: starting vite subprocess", "dir", s.workDir, "port", port)
+
+	cmd := exec.Command("npm", "run", "dev", "--", "--port", port, "--strictPort")
+	cmd.Dir = s.workDir
+	cmd.Stdout = newPrefixedWriter("vite", os.Stdout)
+	cmd.Stderr = newPrefixedWriter("vite", os.Stderr)
+	// New process group — Stop can SIGTERM the whole tree.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("dev: start vite: %w", err)
+	}
+	s.cmd = cmd
+	s.spawned = true
+
+	if err := waitForReachable(s.addr, timeout); err != nil {
+		_ = s.stopLocked()
+		return fmt.Errorf("dev: vite never became reachable on %s within %s: %w", s.addr, timeout, err)
+	}
+	slog.Info("dev: vite ready", "addr", s.addr)
+	return nil
+}
+
+// Stop signals the spawned Vite to terminate (process-group SIGTERM)
+// and waits for it to exit. No-op if we attached to an externally-
+// managed Vite or never spawned one.
+func (s *ViteSupervisor) Stop() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.stopLocked()
+}
+
+func (s *ViteSupervisor) stopLocked() error {
+	if !s.spawned || s.cmd == nil || s.cmd.Process == nil {
+		return nil
+	}
+	pgid, err := syscall.Getpgid(s.cmd.Process.Pid)
+	if err == nil && pgid > 0 {
+		_ = syscall.Kill(-pgid, syscall.SIGTERM)
+	} else {
+		_ = s.cmd.Process.Signal(syscall.SIGTERM)
+	}
+	// Give it a moment; if it ignores SIGTERM, force-kill.
+	done := make(chan error, 1)
+	go func() { done <- s.cmd.Wait() }()
+	select {
+	case waitErr := <-done:
+		s.cmd = nil
+		s.spawned = false
+		// Exit-status errors from a SIGTERM kill are expected — only
+		// surface unrelated failures.
+		var exit *exec.ExitError
+		if errors.As(waitErr, &exit) {
+			return nil
+		}
+		return waitErr
+	case <-time.After(5 * time.Second):
+		if pgid > 0 {
+			_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		} else {
+			_ = s.cmd.Process.Kill()
+		}
+		<-done
+		s.cmd = nil
+		s.spawned = false
+		return errors.New("dev: vite did not stop within 5s, force-killed")
+	}
+}
+
+// reachable returns true if a TCP connection to the address's host:port
+// succeeds within the given timeout.
+func reachable(rawURL string, timeout time.Duration) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	conn, err := net.DialTimeout("tcp", u.Host, timeout)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+func waitForReachable(rawURL string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if reachable(rawURL, 250*time.Millisecond) {
+			return nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return errors.New("timeout")
+}
+
+func portFromAddr(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "5173"
+	}
+	_, port, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		return "5173"
+	}
+	return port
+}
+
+// prefixedWriter forwards writes to `out`, prepending each line with
+// `[prefix] ` so logs from the Vite child are distinguishable from the
+// Go process's own slog output. Lines are buffered until the trailing
+// newline arrives so multi-byte writes don't get split.
+type prefixedWriter struct {
+	prefix string
+	out    io.Writer
+
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+func newPrefixedWriter(prefix string, out io.Writer) *prefixedWriter {
+	return &prefixedWriter{prefix: prefix, out: out}
+}
+
+func (w *prefixedWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	_, _ = w.buf.WriteString(string(p))
+	for {
+		s := w.buf.String()
+		nl := strings.IndexByte(s, '\n')
+		if nl < 0 {
+			break
+		}
+		line := s[:nl]
+		fmt.Fprintf(w.out, "[%s] %s\n", w.prefix, line)
+		w.buf.Reset()
+		_, _ = w.buf.WriteString(s[nl+1:])
+	}
+	return len(p), nil
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -17,6 +17,19 @@ const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(file
 // is a dev-time-only concern.
 const BACKEND_URL = process.env.VITE_BACKEND_URL ?? 'http://localhost:8080';
 
+// HMR client port — when the developer is running the Go binary with
+// `-tags dev`, the browser hits the Go process on :8080 and Go reverse-
+// proxies SPA requests to Vite on :5173. The HMR WebSocket goes through
+// the same proxy, so the browser must connect back to :8080 (the user-
+// facing port), NOT :5173 (the Vite-internal port). Without this, Vite
+// generates HMR URLs pointing at :5173, which the browser can't reach
+// behind the proxy.
+//
+// Set VITE_HMR_CLIENT_PORT=5173 (or unset) when running `npm run dev`
+// standalone — i.e. browsing Vite directly at :5173 without the Go
+// proxy in front.
+const HMR_CLIENT_PORT = Number(process.env.VITE_HMR_CLIENT_PORT ?? 8080);
+
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
   plugins: [react()],
@@ -26,6 +39,10 @@ export default defineConfig({
         target: BACKEND_URL,
         changeOrigin: true,
       },
+    },
+    hmr: {
+      // See HMR_CLIENT_PORT above.
+      clientPort: HMR_CLIENT_PORT,
     },
   },
   test: {


### PR DESCRIPTION
## Summary

- Adds a `-tags dev` build flavour for ocs-testbench that fronts the Go HTTP server with a reverse proxy to Vite, giving a Quarkus-like single-port dev experience: browser hits `:8080`, Go owns `/api/*`, everything else (SPA assets + HMR socket) is proxied to Vite on `:5173`.
- The Go process spawns `npm run dev` itself if Vite isn't already running, and SIGTERMs the whole process group cleanly on shutdown.
- Production behaviour unchanged: plain `go build` produces the embed-only binary as before.

## What's new

- `internal/appl/frontend_dev.go` (`//go:build dev`) — `DevFrontendHandler` (`httputil.NewSingleHostReverseProxy`; WebSocket Upgrade for HMR is transparent in Go 1.12+) and `ViteSupervisor` (probes :5173, attaches if reachable, spawns `npm run dev` if not, force-kills the process group after 5s SIGTERM grace).
- `cmd/ocs-testbench/devmode.go` (`!dev`) — no-op stub returning `(nil, nil)`. Keeps `runWith` build-tag agnostic.
- `cmd/ocs-testbench/devmode_dev.go` (`dev`) — wires the supervisor + handler, registers `Stop` on lifecycle shutdown so Vite dies with the Go process.
- `cmd/ocs-testbench/devmode_iface.go` — shared `shutdownRegistrar` interface so both build flavours type-check.
- `cmd/ocs-testbench/main.go` — single branch in `runWith`: dev hook runs first, nil result falls through to the existing embed path.
- `cmd/ocs-testbench/main_test.go` — tagged `!dev` (the bootstrap test exercises `runWith` end-to-end and would try to spawn Vite under the dev build).
- `web/vite.config.ts` — `server.hmr.clientPort: 8080` (overridable via `VITE_HMR_CLIENT_PORT`), so the HMR WebSocket reconnects to the user-facing port.

## Verified

- `go build ./...` and `go test ./...` (default flavour) — green.
- `go build -tags dev ./...` — compiles cleanly.
- `go test -tags dev ./internal/appl/...` — passes.
- `go run -tags dev ./cmd/ocs-testbench` — supervisor attached to existing Vite, browser at `:8080` rendered the SPA with mocks active, HMR confirmed live (file edits reflect within <1s, no full reload).

## Test plan

- [ ] `go build ./...` clean
- [ ] `go test ./...` clean
- [ ] `go build -tags dev ./...` clean
- [ ] `go run -tags dev ./cmd/ocs-testbench` — browse `:8080`, see app with mocks, edit a `.tsx`, observe HMR
- [ ] Plain `go run ./cmd/ocs-testbench` — embed path serves; no Vite spawned

## Usage

```sh
# dev: one command, single port
go run -tags dev ./cmd/ocs-testbench
# (Go spawns npm run dev if Vite isn't already running, kills it on shutdown)

# prod: unchanged
cd web && npm run build && cd ..
go build ./cmd/ocs-testbench
./ocs-testbench
```