### PR TITLE
feat: Diameter stack — multi-peer manager + CCR/CCA messaging + protocol behaviour (Tasks 3–5 of #17)

### DIFF
--- a/cmd/ocs-testbench/main.go
+++ b/cmd/ocs-testbench/main.go
@@ -16,22 +16,26 @@
 //  3. Reconfigure logging from cfg.Logging.
 //  4. Open the production store (pgx pool) and register its close as
 //     the first shutdown callback.
-//  5. (TODO) Wire the Diameter stack — placeholder until Feature lands.
+//  5. Load AVP dictionaries (built-in + active custom) via
+//     internal/diameter/dictionary.Loader, then construct and start
+//     the multi-peer Diameter Manager — peers come from the store
+//     via StorePeerProvider; AutoConnect=true peers initiate their
+//     lifecycle inside Start.
 //  6. (TODO) Mount the REST API router — placeholder until Feature lands.
 //  7. Build the chi HTTP router with the request-logging middleware
 //     and mount the embedded frontend handler as the not-found
 //     fallback (so API routes added in step 6 take precedence).
 //  8. Start the metrics server via appl.Lifecycle.StartMetrics, placed
-//     between the store-shutdown registration and the HTTP-shutdown
-//     registration so the reverse-of-registration drain order yields
-//     HTTP → metrics → store.
+//     between the diameter-manager shutdown registration and the
+//     HTTP-shutdown registration so the reverse-of-registration drain
+//     order yields HTTP → metrics → diameter-manager → store.
 //  9. Start the HTTP server on cfg.Server.Addr.
 //  10. Optionally auto-open the default browser (gated by
 //     cfg.Frontend.AutoOpenBrowser && !cfg.Headless).
 //  11. Block on lifecycle.Run, which installs the SIGTERM/SIGINT/SIGQUIT
 //     handler and waits for any of them (or ctx cancellation).
 //  12. Shutdown drains the registered callbacks in reverse order:
-//     HTTP server → metrics server → store close.
+//     HTTP server → metrics server → diameter-manager → store close.
 package main
 
 import (
@@ -44,11 +48,14 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/fiorix/go-diameter/v4/diam/dict"
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/eddiecarpenter/ocs-testbench/internal/appl"
 	"github.com/eddiecarpenter/ocs-testbench/internal/baseconfig"
+	"github.com/eddiecarpenter/ocs-testbench/internal/diameter/dictionary"
+	"github.com/eddiecarpenter/ocs-testbench/internal/diameter/manager"
 	"github.com/eddiecarpenter/ocs-testbench/internal/logging"
 	"github.com/eddiecarpenter/ocs-testbench/internal/store"
 	"github.com/eddiecarpenter/ocs-testbench/web"
@@ -159,17 +166,39 @@ func runWith(ctx context.Context, cfg *baseconfig.Config, s store.Store, embedde
 		}
 	}
 
+	// Load AVP dictionaries (built-in + active custom) before any
+	// peer connection is opened. Per Feature #17 design plan and
+	// AC-7/AC-8/AC-9: built-ins are loaded by go-diameter's package
+	// init(); the loader extends dict.Default with active custom
+	// dictionaries from the store and fails-soft on per-record XML
+	// errors.
+	loader := dictionary.NewLoader(dictionary.NewStoreSource(s))
+	if _, err := loader.Load(ctx); err != nil {
+		// A loader fatal error (built-ins missing, store list
+		// failed) is non-recoverable — fail startup. Per-record
+		// XML errors are logged-and-skipped inside Load and never
+		// surface here.
+		s.Close()
+		return fmt.Errorf("ocs-testbench: load diameter dictionaries: %w", err)
+	}
+
+	// Construct and start the Diameter Manager. Peers come from
+	// the store via StorePeerProvider; auto-connect peers initiate
+	// their lifecycle inside Start. Manager.Stop is registered as
+	// a shutdown callback so the reverse-drain order is
+	// HTTP → manager → metrics → store.
+	dmgr := manager.New(dict.Default, manager.NewStorePeerProvider(s))
+	if err := dmgr.Start(ctx); err != nil {
+		s.Close()
+		return fmt.Errorf("ocs-testbench: start diameter manager: %w", err)
+	}
+
 	router := chi.NewRouter()
 	router.Use(logging.RequestLogger)
 
-	// TODO(feature: diameter): wire the Diameter stack here when
-	// internal/diameter lands. Expected shape:
-	//   stack, err := diameter.New(cfg.Peers, ...)
-	//   lc.RegisterShutdown("diameter", stack.Close)
-
 	// TODO(feature: api): mount the REST + SSE routes here when
 	// internal/api lands. Expected shape:
-	//   api.Mount(router, s, ...)
+	//   api.Mount(router, s, dmgr, ...)
 
 	// SPA fallback last — chi's NotFound handler runs after every
 	// explicit route declared above (none yet, by design).
@@ -198,15 +227,22 @@ func runWith(ctx context.Context, cfg *baseconfig.Config, s store.Store, embedde
 	}()
 
 	// Shutdown registration order is the REVERSE of desired drain
-	// order. Drain order per Feature scope: HTTP → metrics → store.
-	// Therefore registration order: store, metrics, HTTP.
+	// order. Drain order: HTTP → metrics → diameter-manager → store.
+	// Therefore registration order: store, diameter-manager, metrics,
+	// HTTP. The manager's Stop() drains reconnect goroutines and
+	// closes every per-peer transport before the store is closed.
 	lc.RegisterShutdown("store", func(context.Context) error {
 		s.Close()
+		return nil
+	})
+	lc.RegisterShutdown("diameter-manager", func(context.Context) error {
+		dmgr.Stop()
 		return nil
 	})
 	if err := lc.StartMetrics(); err != nil {
 		// Best-effort drain of what's been registered so far before
 		// returning the error.
+		dmgr.Stop()
 		s.Close()
 		return fmt.Errorf("ocs-testbench: start metrics: %w", err)
 	}

--- a/cmd/ocs-testbench/main.go
+++ b/cmd/ocs-testbench/main.go
@@ -20,22 +20,27 @@
 //     internal/diameter/dictionary.Loader, then construct and start
 //     the multi-peer Diameter Manager — peers come from the store
 //     via StorePeerProvider; AutoConnect=true peers initiate their
-//     lifecycle inside Start.
+//     lifecycle inside Start. Build the engine-facing Sender as a
+//     protocol.Behaviour-wrapped messaging.Sender so the
+//     protocol-mandated CCA behaviours (FUI-TERMINATE,
+//     Validity-Time, 5xxx) fire automatically.
 //  6. (TODO) Mount the REST API router — placeholder until Feature lands.
 //  7. Build the chi HTTP router with the request-logging middleware
 //     and mount the embedded frontend handler as the not-found
 //     fallback (so API routes added in step 6 take precedence).
 //  8. Start the metrics server via appl.Lifecycle.StartMetrics, placed
-//     between the diameter-manager shutdown registration and the
+//     between the diameter-protocol shutdown registration and the
 //     HTTP-shutdown registration so the reverse-of-registration drain
-//     order yields HTTP → metrics → diameter-manager → store.
+//     order yields
+//     HTTP → metrics → diameter-protocol → diameter-manager → store.
 //  9. Start the HTTP server on cfg.Server.Addr.
 //  10. Optionally auto-open the default browser (gated by
 //     cfg.Frontend.AutoOpenBrowser && !cfg.Headless).
 //  11. Block on lifecycle.Run, which installs the SIGTERM/SIGINT/SIGQUIT
 //     handler and waits for any of them (or ctx cancellation).
 //  12. Shutdown drains the registered callbacks in reverse order:
-//     HTTP server → metrics server → diameter-manager → store close.
+//     HTTP server → metrics server → diameter-protocol →
+//     diameter-manager → store close.
 package main
 
 import (
@@ -56,6 +61,8 @@ import (
 	"github.com/eddiecarpenter/ocs-testbench/internal/baseconfig"
 	"github.com/eddiecarpenter/ocs-testbench/internal/diameter/dictionary"
 	"github.com/eddiecarpenter/ocs-testbench/internal/diameter/manager"
+	"github.com/eddiecarpenter/ocs-testbench/internal/diameter/messaging"
+	"github.com/eddiecarpenter/ocs-testbench/internal/diameter/protocol"
 	"github.com/eddiecarpenter/ocs-testbench/internal/logging"
 	"github.com/eddiecarpenter/ocs-testbench/internal/store"
 	"github.com/eddiecarpenter/ocs-testbench/web"
@@ -193,12 +200,28 @@ func runWith(ctx context.Context, cfg *baseconfig.Config, s store.Store, embedde
 		return fmt.Errorf("ocs-testbench: start diameter manager: %w", err)
 	}
 
+	// Build the engine-facing Sender: a messaging.Sender wrapped
+	// by protocol.Behaviour. The engine layer (when it lands)
+	// receives the wrapped sender; protocol-mandated CCA actions
+	// (FUI-TERMINATE → CCR-T, Validity-Time → CCR-U, 5xxx →
+	// terminate) happen behind the scenes.
+	//
+	// The CCRTerminate / CCRUpdate builders are not yet wired —
+	// they require engine-side per-session state (Service-Context-
+	// Id, Subscription-Id, MSCC) which lands with the engine
+	// itself. The Behaviour still tracks session state and marks
+	// terminated sessions correctly; the auto out-of-band CCRs
+	// are no-ops until the builders are supplied.
+	sender := messaging.NewSender(dmgr)
+	behaviour := protocol.New(sender, protocol.Options{})
+	_ = behaviour // engine consumer lands in a later feature
+
 	router := chi.NewRouter()
 	router.Use(logging.RequestLogger)
 
 	// TODO(feature: api): mount the REST + SSE routes here when
 	// internal/api lands. Expected shape:
-	//   api.Mount(router, s, dmgr, ...)
+	//   api.Mount(router, s, dmgr, behaviour, ...)
 
 	// SPA fallback last — chi's NotFound handler runs after every
 	// explicit route declared above (none yet, by design).
@@ -227,10 +250,13 @@ func runWith(ctx context.Context, cfg *baseconfig.Config, s store.Store, embedde
 	}()
 
 	// Shutdown registration order is the REVERSE of desired drain
-	// order. Drain order: HTTP → metrics → diameter-manager → store.
-	// Therefore registration order: store, diameter-manager, metrics,
-	// HTTP. The manager's Stop() drains reconnect goroutines and
-	// closes every per-peer transport before the store is closed.
+	// order. Drain order:
+	//   HTTP → metrics → diameter-protocol → diameter-manager → store.
+	// Therefore registration order: store, diameter-manager,
+	// diameter-protocol, metrics, HTTP. The protocol Behaviour
+	// stops first (cancels outstanding re-auth timers) so the
+	// manager can then drain transports cleanly before the store
+	// is closed.
 	lc.RegisterShutdown("store", func(context.Context) error {
 		s.Close()
 		return nil
@@ -239,9 +265,14 @@ func runWith(ctx context.Context, cfg *baseconfig.Config, s store.Store, embedde
 		dmgr.Stop()
 		return nil
 	})
+	lc.RegisterShutdown("diameter-protocol", func(context.Context) error {
+		behaviour.Stop()
+		return nil
+	})
 	if err := lc.StartMetrics(); err != nil {
 		// Best-effort drain of what's been registered so far before
 		// returning the error.
+		behaviour.Stop()
 		dmgr.Stop()
 		s.Close()
 		return fmt.Errorf("ocs-testbench: start metrics: %w", err)

--- a/internal/diameter/conn/connection.go
+++ b/internal/diameter/conn/connection.go
@@ -74,6 +74,10 @@ func realDial(_ context.Context, cli *sm.Client, cfg diameter.PeerConfig) (diam.
 //   - Subscribe returns a typed StateEvent channel for fan-out.
 //   - Conn returns the live diam.Conn while connected (used by the
 //     Sender in task 4); returns nil otherwise.
+//   - HandleFunc registers a per-command incoming-message handler
+//     (e.g. "CCA") that is reapplied to every fresh sm.Client
+//     across reconnects. The Sender (task 4) uses this to install
+//     a CCA correlator before any messages are sent.
 //
 // Concurrency: every public method is goroutine-safe.
 type PeerConnection struct {
@@ -96,6 +100,16 @@ type PeerConnection struct {
 	// Sender (task 4) can read it under the same lock that the
 	// lifecycle goroutine uses to swap it in.
 	activeConn diam.Conn
+	// activeMgr is the sm.StateMachine bound to activeConn. The
+	// HandleFunc method applies user-registered handlers to it
+	// immediately so a Sender registering "CCA" after the
+	// connection is up still sees responses.
+	activeMgr *sm.StateMachine
+	// handlers is the slice of (command, handler) pairs the
+	// caller has registered via HandleFunc. Re-applied to every
+	// fresh sm.Client constructed in dialOnce so a reconnect
+	// preserves the user's handler installation.
+	handlers []handlerEntry
 
 	// Tunables — defaults applied in New. Exposed in the package
 	// (lower-case) so the test seam can override them without
@@ -107,6 +121,55 @@ type PeerConnection struct {
 
 	// dial is the seam used by tests; production uses realDial.
 	dial dialFunc
+}
+
+// handlerEntry is one user-registered command handler. The handler
+// is invoked by the underlying sm.StateMachine (which is itself a
+// ServeMux) when an incoming message matches the command.
+type handlerEntry struct {
+	cmd     string
+	handler diam.HandlerFunc
+}
+
+// HandleFunc registers a handler invoked for every incoming
+// Diameter message whose short command name equals cmd (e.g.
+// "CCA", "RAR"). The handler is reapplied to every fresh sm.Client
+// created across reconnects — callers register once at
+// construction time and the connection layer takes care of
+// re-installing on each dial attempt.
+//
+// HandleFunc is safe to call from any state. If the connection is
+// currently connected and a handler with the same command already
+// exists, the existing entry is replaced; otherwise the new
+// handler is appended. This matches the behaviour callers want
+// when they subscribe to a command after a reconnect.
+//
+// CER, CEA, DWR, DWA are reserved by go-diameter's StateMachine —
+// registering a handler for those commands will be silently
+// shadowed by the StateMachine's built-in handlers. The Sender
+// (task 4) registers "CCA" only; protocol-mandated handlers for
+// out-of-band CCRs (CCR-Terminate from FUI) flow back through the
+// same Sender path and do not need a separate registration.
+func (pc *PeerConnection) HandleFunc(cmd string, handler diam.HandlerFunc) {
+	pc.muLife.Lock()
+	defer pc.muLife.Unlock()
+	found := false
+	for i := range pc.handlers {
+		if pc.handlers[i].cmd == cmd {
+			pc.handlers[i].handler = handler
+			found = true
+			break
+		}
+	}
+	if !found {
+		pc.handlers = append(pc.handlers, handlerEntry{cmd: cmd, handler: handler})
+	}
+	// If a live StateMachine exists (the connection is up or
+	// connecting), apply the handler now so callers registering
+	// after Connect still see incoming messages.
+	if pc.activeMgr != nil {
+		pc.activeMgr.HandleFunc(cmd, handler)
+	}
 }
 
 // New constructs a PeerConnection bound to the given config and
@@ -262,6 +325,7 @@ func (pc *PeerConnection) run(ctx context.Context) {
 			pc.activeConn.Close()
 			pc.activeConn = nil
 		}
+		pc.activeMgr = nil
 		pc.muLife.Unlock()
 	}()
 
@@ -344,9 +408,19 @@ func (pc *PeerConnection) waitForDrop(ctx context.Context, c diam.Conn) bool {
 // dictionary, sm.Settings, and sm.Client are constructed fresh per
 // attempt because the underlying StateMachine is not safe to reuse
 // across reconnects (handshake-channel state is per-attempt).
+//
+// User-registered handlers (added via HandleFunc) are re-applied
+// to the fresh StateMachine before the dial — this is what gives
+// callers a stable handler set across reconnects.
 func (pc *PeerConnection) dialOnce(ctx context.Context) (diam.Conn, error) {
 	settings := buildSettings(pc.cfg, pc.parser)
 	mgr := sm.New(settings)
+	pc.muLife.Lock()
+	for _, h := range pc.handlers {
+		mgr.HandleFunc(h.cmd, h.handler)
+	}
+	pc.activeMgr = mgr
+	pc.muLife.Unlock()
 	client := &sm.Client{
 		Dict:               pc.parser,
 		Handler:            mgr,

--- a/internal/diameter/manager/doc.go
+++ b/internal/diameter/manager/doc.go
@@ -1,0 +1,31 @@
+// Package manager is the multi-peer connection registry of the OCS
+// Testbench's Diameter stack.
+//
+// The Manager owns a map of named peer connections (one per
+// PeerConfig) keyed by peer name. Each entry composes a
+// conn.PeerConnection from internal/diameter/conn — the manager does
+// not inherit from or wrap the connection's lifecycle, it simply
+// registers and dispatches.
+//
+// Responsibilities:
+//
+//   - Register peers on Start(ctx) from a PeerProvider — one
+//     conn.PeerConnection per peer, each with the peer's own
+//     Origin-Host, Origin-Realm and isolated session space.
+//   - Auto-connect peers whose PeerConfig.AutoConnect is true.
+//   - Hand out per-peer connection handles via Get(name) so the
+//     messaging layer (Task 4) can resolve peerName → connection.
+//   - Provide a manager-level subscriber channel via Subscribe()
+//     that fans out StateEvent values from every PeerConnection
+//     onto a single stream — the consumer subscribes once and sees
+//     every peer's transitions. (Task 4 / Feature #9 will use this.)
+//   - Drain reconnect goroutines and close transports cleanly on
+//     Stop().
+//
+// The manager package does NOT import internal/store. The peer
+// configs flow in through the PeerProvider interface; the
+// orchestrator (cmd/ocs-testbench/main.go) is responsible for
+// reading the peer rows out of the store, decoding them into
+// diameter.PeerConfig, and feeding them via a PeerProvider
+// implementation. This preserves the §14 core-separation invariant.
+package manager

--- a/internal/diameter/manager/manager.go
+++ b/internal/diameter/manager/manager.go
@@ -1,0 +1,498 @@
+package manager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/fiorix/go-diameter/v4/diam"
+	"github.com/fiorix/go-diameter/v4/diam/dict"
+
+	"github.com/eddiecarpenter/ocs-testbench/internal/diameter"
+	"github.com/eddiecarpenter/ocs-testbench/internal/diameter/conn"
+	"github.com/eddiecarpenter/ocs-testbench/internal/logging"
+)
+
+// PeerProvider is the read-only source the Manager consumes at
+// Start time to discover the peers it should register. The
+// orchestrator (cmd/ocs-testbench/main.go) supplies a production
+// implementation that decodes the peer rows out of internal/store;
+// tests supply a fixed slice via SlicePeerProvider.
+//
+// ListPeers is called exactly once per Start. The Manager does not
+// subscribe to provider changes — adding or removing a peer at
+// runtime is out of scope for Feature #17 and would land as part
+// of the future API layer (Feature #8).
+type PeerProvider interface {
+	// ListPeers returns the peer configs the Manager should
+	// register. Returning an error halts Start with that error
+	// propagated to the caller. An empty slice is valid and
+	// produces a Manager that runs but registers zero peers.
+	ListPeers(ctx context.Context) ([]diameter.PeerConfig, error)
+}
+
+// SlicePeerProvider is the trivial PeerProvider used by tests and by
+// any caller that already has the list of configs in hand. The
+// production wiring uses a thin adapter over internal/store.Store
+// (see cmd/ocs-testbench/main.go).
+type SlicePeerProvider struct {
+	Configs []diameter.PeerConfig
+}
+
+// ListPeers returns the embedded slice. Always nil error.
+func (s SlicePeerProvider) ListPeers(_ context.Context) ([]diameter.PeerConfig, error) {
+	return append([]diameter.PeerConfig(nil), s.Configs...), nil
+}
+
+// PeerConnection is the slice of conn.PeerConnection the Manager
+// hands out via Get. Defined as its own interface so tests can
+// substitute a fake without spinning up a goroutine and a real
+// go-diameter dialler — the manager-level registry / fan-out
+// semantics are independent of the underlying connection's
+// go-diameter behaviour. The interface is also the contract Task 4's
+// messaging.Sender will consume.
+//
+// The surface mirrors the public methods of *conn.PeerConnection
+// the Manager and its callers actually call. Conn returns the live
+// go-diameter connection while the peer is in StateConnected — the
+// messaging Sender uses it to write a CCR; the manager itself never
+// reaches for it.
+type PeerConnection interface {
+	Connect(ctx context.Context) error
+	Disconnect()
+	State() diameter.ConnectionState
+	Subscribe() <-chan diameter.StateEvent
+	Config() diameter.PeerConfig
+	Conn() diam.Conn
+}
+
+// ConnectionFactory is the seam tests use to substitute a fake
+// peer-connection. Production wiring uses the closure constructed
+// by New that delegates to conn.New.
+type ConnectionFactory func(cfg diameter.PeerConfig, parser *dict.Parser) PeerConnection
+
+// Manager is the multi-peer connection registry.
+//
+// Construct via New. Lifecycle:
+//
+//   - New constructs an empty Manager bound to a dictionary parser
+//     (typically dict.Default after the loader has populated it).
+//   - Start(ctx) reads peers from the PeerProvider, builds one
+//     PeerConnection per peer, and fires Connect on every peer
+//     marked autoConnect=true. Returns once registration is
+//     complete; auto-connect outcomes flow asynchronously through
+//     the subscriber channel.
+//   - Connect(name) / Disconnect(name) operate on a single peer
+//     post-Start (typically used by the future REST layer #8).
+//   - Get(name) returns the *conn.PeerConnection (production type)
+//     for callers that need the live diam.Conn — the messaging
+//     Sender (Task 4) uses this.
+//   - Subscribe() returns a manager-level event channel that fans
+//     out StateEvents from every registered peer.
+//   - Stop() cancels the manager-level context, waits for every
+//     PeerConnection's lifecycle goroutine to drain, closes every
+//     subscriber channel, and clears the registry.
+//
+// Concurrency: every public method is goroutine-safe.
+type Manager struct {
+	parser   *dict.Parser
+	provider PeerProvider
+	factory  ConnectionFactory
+
+	mu      sync.Mutex
+	peers   map[string]*peerEntry
+	started bool
+	stopped bool
+
+	// rootCtx is the lifecycle context shared by every
+	// PeerConnection's Connect call; populated by Start.
+	// rootCancel cancels it.
+	rootCtx    context.Context
+	rootCancel context.CancelFunc
+	// fanCtx, fanCancel control the manager's fan-out goroutines —
+	// one per registered peer. fanCancel fires before PeerConnection
+	// Disconnect so the fan-out stops reading from the per-peer
+	// subscriber channel before the peer closes it.
+	fanCtx    context.Context
+	fanCancel context.CancelFunc
+	fanWG     sync.WaitGroup
+
+	// subs holds the manager-level subscribers (fan-out).
+	subs *subscriberSet
+}
+
+// peerEntry is the manager-level record for one registered peer.
+type peerEntry struct {
+	conn PeerConnection //nolint:revive // intentional field name; matches manager.PeerConnection interface
+	cfg  diameter.PeerConfig
+}
+
+// Sentinel errors raised by the Manager. Callers branch on these via
+// errors.Is.
+var (
+	// ErrUnknownPeer is returned by Connect/Disconnect/Get when the
+	// supplied name is not registered.
+	ErrUnknownPeer = errors.New("manager: unknown peer")
+	// ErrAlreadyStarted is returned by Start when the Manager has
+	// already been started.
+	ErrAlreadyStarted = errors.New("manager: already started")
+	// ErrNotStarted is returned by Connect/Disconnect/Get when the
+	// Manager has not yet been started.
+	ErrNotStarted = errors.New("manager: not started")
+	// ErrStopped is returned by Connect/Disconnect after Stop has
+	// drained the registry.
+	ErrStopped = errors.New("manager: stopped")
+	// ErrDuplicatePeer is returned by Start when the provider
+	// supplies two configs with the same Name.
+	ErrDuplicatePeer = errors.New("manager: duplicate peer name")
+)
+
+// New constructs a Manager bound to the given dictionary parser and
+// PeerProvider. Pass dict.Default in production so the manager's
+// PeerConnections share the dictionary the loader (Task 1)
+// populated; tests pass a fresh parser to keep dict.Default
+// unmutated.
+//
+// Panics on a nil parser or a nil provider — both are wiring bugs
+// that should fail loudly at startup.
+func New(parser *dict.Parser, provider PeerProvider) *Manager {
+	if parser == nil {
+		panic("manager.New: parser must not be nil")
+	}
+	if provider == nil {
+		panic("manager.New: provider must not be nil")
+	}
+	return &Manager{
+		parser:   parser,
+		provider: provider,
+		factory:  productionFactory,
+		peers:    map[string]*peerEntry{},
+		subs:     newSubscriberSet(),
+	}
+}
+
+// productionFactory is the ConnectionFactory used in production. It
+// delegates to conn.New, which spins up a real PeerConnection
+// against go-diameter.
+func productionFactory(cfg diameter.PeerConfig, parser *dict.Parser) PeerConnection {
+	return conn.New(cfg, parser)
+}
+
+// SetFactory replaces the connection factory. Tests use this to
+// swap in a fake PeerConnection that doesn't dial. Returns the
+// previous factory so the caller can restore it via defer.
+//
+// Production code MUST NOT call this — the default factory
+// (productionFactory) is what makes the manager actually open
+// connections.
+func (m *Manager) SetFactory(f ConnectionFactory) ConnectionFactory {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	prev := m.factory
+	if f != nil {
+		m.factory = f
+	}
+	return prev
+}
+
+// Start registers every peer the provider returns, wires their
+// per-peer subscriber channels into the manager-level fan-out, and
+// fires Connect for every peer marked AutoConnect=true.
+//
+// Start is single-shot — calling it twice returns
+// ErrAlreadyStarted.
+//
+// The supplied ctx becomes the root context for every
+// PeerConnection's lifecycle goroutine. Cancelling it has the same
+// effect as Stop(). Production wiring passes the application's
+// root context so a SIGTERM tears the whole stack down cleanly.
+func (m *Manager) Start(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("manager.Start: ctx is nil")
+	}
+
+	m.mu.Lock()
+	if m.started {
+		m.mu.Unlock()
+		return ErrAlreadyStarted
+	}
+	m.started = true
+	rootCtx, rootCancel := context.WithCancel(ctx)
+	m.rootCtx = rootCtx
+	m.rootCancel = rootCancel
+	fanCtx, fanCancel := context.WithCancel(rootCtx)
+	m.fanCtx = fanCtx
+	m.fanCancel = fanCancel
+	factory := m.factory
+	m.mu.Unlock()
+
+	configs, err := m.provider.ListPeers(ctx)
+	if err != nil {
+		// Best-effort cleanup so a failed Start leaves the manager
+		// in a fresh-construct equivalent state.
+		m.mu.Lock()
+		m.started = false
+		m.rootCtx = nil
+		m.rootCancel = nil
+		m.fanCtx = nil
+		m.fanCancel = nil
+		m.mu.Unlock()
+		rootCancel()
+		return fmt.Errorf("manager: list peers: %w", err)
+	}
+
+	// Detect duplicate names early — registering two peers under
+	// the same key is a wiring bug the manager refuses to mask.
+	seen := make(map[string]struct{}, len(configs))
+	for _, cfg := range configs {
+		if _, exists := seen[cfg.Name]; exists {
+			m.mu.Lock()
+			m.started = false
+			m.rootCancel = nil
+			m.fanCtx = nil
+			m.fanCancel = nil
+			m.mu.Unlock()
+			rootCancel()
+			return fmt.Errorf("%w: %q", ErrDuplicatePeer, cfg.Name)
+		}
+		seen[cfg.Name] = struct{}{}
+	}
+
+	// Register every peer first so a partial-Start failure can be
+	// torn down via Stop without leaking a half-built registry.
+	autoConnect := make([]string, 0, len(configs))
+	for _, cfg := range configs {
+		entry := &peerEntry{
+			cfg:  cfg,
+			conn: factory(cfg, m.parser),
+		}
+		m.mu.Lock()
+		m.peers[cfg.Name] = entry
+		m.mu.Unlock()
+
+		// Wire the per-peer subscriber into the manager-level
+		// fan-out goroutine. The subscription is taken before any
+		// Connect so we do not miss the first transitions.
+		ch := entry.conn.Subscribe()
+		m.fanWG.Add(1)
+		go m.fanOut(fanCtx, cfg.Name, ch)
+
+		if cfg.AutoConnect {
+			autoConnect = append(autoConnect, cfg.Name)
+		}
+	}
+
+	// Auto-connect after every peer is registered so a peer's
+	// connect-failure cannot prevent another peer from being
+	// registered.
+	for _, name := range autoConnect {
+		m.mu.Lock()
+		entry := m.peers[name]
+		m.mu.Unlock()
+		if entry == nil {
+			continue
+		}
+		if err := entry.conn.Connect(rootCtx); err != nil {
+			// Auto-connect errors are surfaced as warnings — the
+			// peer stays registered (operator can retry via
+			// Connect(name)) but the Start does not fail. AC-4
+			// requires peer independence: a faulting peer must
+			// not break Start.
+			logging.Warn(
+				"manager: auto-connect failed",
+				"peer", name,
+				"error", err.Error(),
+			)
+		}
+	}
+
+	logging.Info(
+		"manager: started",
+		"peers_total", len(configs),
+		"peers_auto_connect", len(autoConnect),
+	)
+	return nil
+}
+
+// Stop cancels the manager-level context, waits for every
+// PeerConnection's lifecycle goroutine to drain, closes every
+// manager-level subscriber channel, and clears the registry.
+//
+// Idempotent — calling Stop twice is safe; the second call is a
+// no-op.
+func (m *Manager) Stop() {
+	m.mu.Lock()
+	if !m.started || m.stopped {
+		m.mu.Unlock()
+		return
+	}
+	m.stopped = true
+	rootCancel := m.rootCancel
+	fanCancel := m.fanCancel
+	peers := m.peers
+	m.peers = map[string]*peerEntry{}
+	m.mu.Unlock()
+
+	// Step 1: Disconnect every peer first. This makes the
+	// per-peer subscriber channels close, which is what the
+	// fan-out goroutines watch as a termination signal.
+	for _, entry := range peers {
+		entry.conn.Disconnect()
+	}
+
+	// Step 2: Cancel the manager-level fan-out context (in case
+	// any fan-out goroutine is blocked on a never-closing
+	// channel) and wait for them to drain.
+	if fanCancel != nil {
+		fanCancel()
+	}
+	m.fanWG.Wait()
+
+	// Step 3: Cancel the root context so any in-flight Connect
+	// goroutine exits.
+	if rootCancel != nil {
+		rootCancel()
+	}
+
+	// Step 4: Close manager-level subscribers and reset.
+	m.subs.closeAll()
+
+	logging.Info("manager: stopped")
+}
+
+// Connect opens (or re-arms) the lifecycle goroutine for the named
+// peer. Returns ErrUnknownPeer if name is not registered;
+// ErrNotStarted if the Manager has not been started.
+//
+// Idempotent on the start state — Connect against a peer whose
+// goroutine is already running returns ErrPeerAlreadyConnected
+// (from the underlying conn package).
+func (m *Manager) Connect(name string) error {
+	m.mu.Lock()
+	if !m.started {
+		m.mu.Unlock()
+		return ErrNotStarted
+	}
+	if m.stopped {
+		m.mu.Unlock()
+		return ErrStopped
+	}
+	entry, ok := m.peers[name]
+	rootCtx := m.rootCtx
+	m.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrUnknownPeer, name)
+	}
+	if rootCtx == nil {
+		return ErrStopped
+	}
+	return entry.conn.Connect(rootCtx)
+}
+
+// Disconnect cancels the lifecycle goroutine for the named peer.
+// Returns ErrUnknownPeer if name is not registered.
+//
+// Idempotent — safe to call against an already-disconnected peer.
+func (m *Manager) Disconnect(name string) error {
+	m.mu.Lock()
+	if !m.started {
+		m.mu.Unlock()
+		return ErrNotStarted
+	}
+	if m.stopped {
+		m.mu.Unlock()
+		return ErrStopped
+	}
+	entry, ok := m.peers[name]
+	m.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrUnknownPeer, name)
+	}
+	entry.conn.Disconnect()
+	return nil
+}
+
+// Get returns the underlying peer-connection for the named peer.
+// The Sender (Task 4) calls this to acquire the *conn.PeerConnection
+// it then sends a CCR over.
+//
+// Returns nil and ErrUnknownPeer if name is not registered. The
+// returned interface points at the production *conn.PeerConnection
+// in normal operation; tests that swap in a fake via SetFactory get
+// their fake back.
+func (m *Manager) Get(name string) (PeerConnection, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.started {
+		return nil, ErrNotStarted
+	}
+	if m.stopped {
+		return nil, ErrStopped
+	}
+	entry, ok := m.peers[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrUnknownPeer, name)
+	}
+	return entry.conn, nil
+}
+
+// State returns the current state for the named peer. Convenience
+// over Get().State().
+func (m *Manager) State(name string) (diameter.ConnectionState, error) {
+	pc, err := m.Get(name)
+	if err != nil {
+		return diameter.StateDisconnected, err
+	}
+	return pc.State(), nil
+}
+
+// Names returns the peer names currently registered, in
+// alphabetical order. Used by callers (and tests) that want to
+// enumerate the registry.
+func (m *Manager) Names() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, 0, len(m.peers))
+	for name := range m.peers {
+		out = append(out, name)
+	}
+	sortStrings(out)
+	return out
+}
+
+// Subscribe returns a manager-level StateEvent channel that fans
+// out events from every registered peer. The channel is closed
+// when Stop drains the registry.
+func (m *Manager) Subscribe() <-chan diameter.StateEvent {
+	return m.subs.add()
+}
+
+// Unsubscribe deregisters a previously-returned subscriber channel.
+// Optional — Stop will close every subscriber channel anyway.
+func (m *Manager) Unsubscribe(ch <-chan diameter.StateEvent) {
+	m.subs.remove(ch)
+}
+
+// fanOut watches a per-peer subscriber channel and forwards every
+// event to the manager-level subscriber set. Exits when the
+// per-peer channel is closed (peer disconnected) or fanCtx is
+// cancelled (manager stopped).
+func (m *Manager) fanOut(ctx context.Context, peerName string, ch <-chan diameter.StateEvent) {
+	defer m.fanWG.Done()
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				return
+			}
+			// Defence in depth: the channel is per-peer so PeerName
+			// is already populated by the conn layer. We do not
+			// rewrite it.
+			_ = peerName
+			m.subs.emit(ev)
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/internal/diameter/manager/manager.go
+++ b/internal/diameter/manager/manager.go
@@ -65,6 +65,7 @@ type PeerConnection interface {
 	Subscribe() <-chan diameter.StateEvent
 	Config() diameter.PeerConfig
 	Conn() diam.Conn
+	HandleFunc(cmd string, handler diam.HandlerFunc)
 }
 
 // ConnectionFactory is the seam tests use to substitute a fake

--- a/internal/diameter/manager/manager_test.go
+++ b/internal/diameter/manager/manager_test.go
@@ -44,8 +44,9 @@ func newFakePeerConnection(cfg diameter.PeerConfig) *fakePeerConnection {
 	}
 }
 
-func (f *fakePeerConnection) Config() diameter.PeerConfig { return f.cfg }
-func (f *fakePeerConnection) Conn() diam.Conn             { return nil }
+func (f *fakePeerConnection) Config() diameter.PeerConfig             { return f.cfg }
+func (f *fakePeerConnection) Conn() diam.Conn                         { return nil }
+func (f *fakePeerConnection) HandleFunc(_ string, _ diam.HandlerFunc) {}
 
 func (f *fakePeerConnection) State() diameter.ConnectionState {
 	f.mu.Lock()

--- a/internal/diameter/manager/manager_test.go
+++ b/internal/diameter/manager/manager_test.go
@@ -1,0 +1,526 @@
+package manager
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/fiorix/go-diameter/v4/diam"
+	"github.com/fiorix/go-diameter/v4/diam/datatype"
+	"github.com/fiorix/go-diameter/v4/diam/diamtest"
+	"github.com/fiorix/go-diameter/v4/diam/dict"
+	"github.com/fiorix/go-diameter/v4/diam/sm"
+
+	"github.com/eddiecarpenter/ocs-testbench/internal/diameter"
+	"github.com/eddiecarpenter/ocs-testbench/internal/diameter/conn"
+)
+
+// fakePeerConnection is the test stand-in for PeerConnection. It
+// records every Connect / Disconnect call, exposes a hand-driven
+// state transition channel via emitState, and never touches the
+// network. The manager-level fan-out and lifecycle logic exercise
+// purely against this fake.
+type fakePeerConnection struct {
+	cfg diameter.PeerConfig
+
+	mu             sync.Mutex
+	connectErr     error
+	connectCount   atomic.Int32
+	disconnectCnt  atomic.Int32
+	currentState   diameter.ConnectionState
+	subscriberCh   chan diameter.StateEvent
+	subscriberOpen bool
+}
+
+func newFakePeerConnection(cfg diameter.PeerConfig) *fakePeerConnection {
+	return &fakePeerConnection{
+		cfg:            cfg,
+		currentState:   diameter.StateDisconnected,
+		subscriberCh:   make(chan diameter.StateEvent, 16),
+		subscriberOpen: true,
+	}
+}
+
+func (f *fakePeerConnection) Config() diameter.PeerConfig { return f.cfg }
+func (f *fakePeerConnection) Conn() diam.Conn             { return nil }
+
+func (f *fakePeerConnection) State() diameter.ConnectionState {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.currentState
+}
+
+func (f *fakePeerConnection) Subscribe() <-chan diameter.StateEvent {
+	return f.subscriberCh
+}
+
+func (f *fakePeerConnection) Connect(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("fakePeerConnection.Connect: nil ctx")
+	}
+	f.connectCount.Add(1)
+	f.mu.Lock()
+	err := f.connectErr
+	f.mu.Unlock()
+	return err
+}
+
+func (f *fakePeerConnection) Disconnect() {
+	f.disconnectCnt.Add(1)
+	f.mu.Lock()
+	if f.subscriberOpen {
+		close(f.subscriberCh)
+		f.subscriberOpen = false
+	}
+	f.mu.Unlock()
+}
+
+// emitState pushes a synthetic transition onto the subscriber
+// channel. Tests use this to drive the manager's fan-out without
+// running a real lifecycle goroutine.
+func (f *fakePeerConnection) emitState(to diameter.ConnectionState, detail string) {
+	f.mu.Lock()
+	from := f.currentState
+	f.currentState = to
+	open := f.subscriberOpen
+	f.mu.Unlock()
+	if !open {
+		return
+	}
+	f.subscriberCh <- diameter.StateEvent{
+		PeerName: f.cfg.Name,
+		From:     from,
+		To:       to,
+		Detail:   detail,
+		Time:     time.Now().UTC(),
+	}
+}
+
+// fakeFactory builds a ConnectionFactory closure that returns a
+// pre-allocated fakePeerConnection per name. The map lets tests
+// assert against the same instances they constructed.
+func fakeFactory(t *testing.T, peers map[string]*fakePeerConnection) ConnectionFactory {
+	t.Helper()
+	return func(cfg diameter.PeerConfig, _ *dict.Parser) PeerConnection {
+		t.Helper()
+		fp, ok := peers[cfg.Name]
+		if !ok {
+			t.Fatalf("fakeFactory: no fake for peer %q", cfg.Name)
+		}
+		return fp
+	}
+}
+
+// withFakes constructs a Manager wired with fake connections for
+// the given configs. Returns the Manager and the per-name fakes
+// the test asserts against.
+func withFakes(t *testing.T, configs []diameter.PeerConfig) (*Manager, map[string]*fakePeerConnection) {
+	t.Helper()
+	fakes := map[string]*fakePeerConnection{}
+	for _, cfg := range configs {
+		fakes[cfg.Name] = newFakePeerConnection(cfg)
+	}
+	m := New(dict.Default, SlicePeerProvider{Configs: configs})
+	m.SetFactory(fakeFactory(t, fakes))
+	return m, fakes
+}
+
+// awaitFanOut waits for an event on the manager-level subscriber
+// channel and returns it. Times out the test on miss.
+func awaitFanOut(t *testing.T, ch <-chan diameter.StateEvent, timeout time.Duration) diameter.StateEvent {
+	t.Helper()
+	select {
+	case ev, ok := <-ch:
+		if !ok {
+			t.Fatalf("manager subscriber channel closed unexpectedly")
+		}
+		return ev
+	case <-time.After(timeout):
+		t.Fatalf("timeout %s waiting for manager fan-out event", timeout)
+		return diameter.StateEvent{}
+	}
+}
+
+// Test 1 (AC-4) — register multiple peers, only auto-connect ones
+// receive Connect; the others remain disconnected.
+func TestManager_StartAutoConnectsOnlyMarkedPeers(t *testing.T) {
+	t.Parallel()
+	configs := []diameter.PeerConfig{
+		{Name: "auto1", Host: "h1", Port: 3868, OriginHost: "oh1", OriginRealm: "or1", AutoConnect: true},
+		{Name: "manual", Host: "h2", Port: 3868, OriginHost: "oh2", OriginRealm: "or2", AutoConnect: false},
+		{Name: "auto2", Host: "h3", Port: 3868, OriginHost: "oh3", OriginRealm: "or3", AutoConnect: true},
+	}
+	m, fakes := withFakes(t, configs)
+	if err := m.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer m.Stop()
+
+	// Auto-connect peers should have Connect called exactly once.
+	if got := fakes["auto1"].connectCount.Load(); got != 1 {
+		t.Errorf("auto1 connect count = %d; want 1", got)
+	}
+	if got := fakes["auto2"].connectCount.Load(); got != 1 {
+		t.Errorf("auto2 connect count = %d; want 1", got)
+	}
+	// Manual peer must not be auto-connected.
+	if got := fakes["manual"].connectCount.Load(); got != 0 {
+		t.Errorf("manual connect count = %d; want 0", got)
+	}
+	// Manual peer remains in disconnected state.
+	if got := fakes["manual"].State(); got != diameter.StateDisconnected {
+		t.Errorf("manual state = %v; want disconnected", got)
+	}
+}
+
+// Test 2 (AC-5) — explicit Connect(name) for a manual peer fires
+// the underlying Connect after Start.
+func TestManager_ExplicitConnectAfterStart(t *testing.T) {
+	t.Parallel()
+	configs := []diameter.PeerConfig{
+		{Name: "p1", Host: "h", Port: 3868, OriginHost: "oh", OriginRealm: "or", AutoConnect: false},
+	}
+	m, fakes := withFakes(t, configs)
+	if err := m.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer m.Stop()
+
+	if got := fakes["p1"].connectCount.Load(); got != 0 {
+		t.Errorf("connect count after start = %d; want 0", got)
+	}
+	if err := m.Connect("p1"); err != nil {
+		t.Fatalf("Connect(p1): %v", err)
+	}
+	if got := fakes["p1"].connectCount.Load(); got != 1 {
+		t.Errorf("connect count after explicit Connect = %d; want 1", got)
+	}
+}
+
+// Test 3 — Connect against an unregistered peer returns
+// ErrUnknownPeer.
+func TestManager_ConnectUnknownReturnsError(t *testing.T) {
+	t.Parallel()
+	m, _ := withFakes(t, []diameter.PeerConfig{
+		{Name: "p1", Host: "h", Port: 3868, OriginHost: "oh", OriginRealm: "or"},
+	})
+	if err := m.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer m.Stop()
+
+	if err := m.Connect("missing"); !errors.Is(err, ErrUnknownPeer) {
+		t.Errorf("Connect(missing) err = %v; want ErrUnknownPeer", err)
+	}
+}
+
+// Test 4 (AC-4) — peers are independent: faulting one peer's
+// auto-connect does not break the registry or sibling peers.
+func TestManager_FaultingPeerDoesNotAffectOthers(t *testing.T) {
+	t.Parallel()
+	configs := []diameter.PeerConfig{
+		{Name: "good", Host: "h", Port: 3868, OriginHost: "oh", OriginRealm: "or", AutoConnect: true},
+		{Name: "bad", Host: "h", Port: 3868, OriginHost: "oh", OriginRealm: "or", AutoConnect: true},
+	}
+	m, fakes := withFakes(t, configs)
+	// "bad" returns an error from Connect; "good" returns nil.
+	fakes["bad"].connectErr = errors.New("dial refused")
+
+	if err := m.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer m.Stop()
+
+	// Both peers were registered (manager survived the bad one).
+	names := m.Names()
+	if len(names) != 2 {
+		t.Errorf("Names() = %v; want 2 entries", names)
+	}
+	// Both Connect attempts were made.
+	if got := fakes["good"].connectCount.Load(); got != 1 {
+		t.Errorf("good connect count = %d; want 1", got)
+	}
+	if got := fakes["bad"].connectCount.Load(); got != 1 {
+		t.Errorf("bad connect count = %d; want 1", got)
+	}
+}
+
+// Test 5 — Stop cancels reconnect goroutines and disconnects every
+// peer. After Stop, Connect returns ErrStopped.
+func TestManager_StopDisconnectsEveryPeer(t *testing.T) {
+	t.Parallel()
+	configs := []diameter.PeerConfig{
+		{Name: "p1", Host: "h", Port: 3868, OriginHost: "oh", OriginRealm: "or", AutoConnect: true},
+		{Name: "p2", Host: "h", Port: 3868, OriginHost: "oh", OriginRealm: "or", AutoConnect: false},
+	}
+	m, fakes := withFakes(t, configs)
+	if err := m.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	m.Stop()
+	if got := fakes["p1"].disconnectCnt.Load(); got != 1 {
+		t.Errorf("p1 disconnect count = %d; want 1", got)
+	}
+	if got := fakes["p2"].disconnectCnt.Load(); got != 1 {
+		t.Errorf("p2 disconnect count = %d; want 1", got)
+	}
+	// Post-Stop Connect/Disconnect return ErrStopped.
+	if err := m.Connect("p1"); !errors.Is(err, ErrStopped) {
+		t.Errorf("Connect after Stop err = %v; want ErrStopped", err)
+	}
+	// Stop is idempotent.
+	m.Stop()
+}
+
+// Test 6 — Subscribe receives fan-out events from every peer.
+func TestManager_SubscribeFansOutEvents(t *testing.T) {
+	t.Parallel()
+	configs := []diameter.PeerConfig{
+		{Name: "p1", Host: "h", Port: 3868, OriginHost: "oh", OriginRealm: "or"},
+		{Name: "p2", Host: "h", Port: 3868, OriginHost: "oh", OriginRealm: "or"},
+	}
+	m, fakes := withFakes(t, configs)
+	if err := m.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer m.Stop()
+
+	ch := m.Subscribe()
+	fakes["p1"].emitState(diameter.StateConnecting, "test")
+	ev1 := awaitFanOut(t, ch, 2*time.Second)
+	if ev1.PeerName != "p1" || ev1.To != diameter.StateConnecting {
+		t.Errorf("first fan-out event = %+v; want p1 connecting", ev1)
+	}
+
+	fakes["p2"].emitState(diameter.StateConnecting, "test")
+	ev2 := awaitFanOut(t, ch, 2*time.Second)
+	if ev2.PeerName != "p2" || ev2.To != diameter.StateConnecting {
+		t.Errorf("second fan-out event = %+v; want p2 connecting", ev2)
+	}
+}
+
+// Test 7 — Manager.Get returns the registered PeerConnection.
+func TestManager_GetReturnsRegisteredConnection(t *testing.T) {
+	t.Parallel()
+	configs := []diameter.PeerConfig{
+		{Name: "p1", Host: "h", Port: 3868, OriginHost: "oh", OriginRealm: "or"},
+	}
+	m, fakes := withFakes(t, configs)
+	if err := m.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer m.Stop()
+
+	pc, err := m.Get("p1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if pc != fakes["p1"] {
+		t.Errorf("Get returned a different PeerConnection than the factory produced")
+	}
+	if _, err := m.Get("missing"); !errors.Is(err, ErrUnknownPeer) {
+		t.Errorf("Get(missing) err = %v; want ErrUnknownPeer", err)
+	}
+}
+
+// Test 8 — duplicate peer names in the provider trigger
+// ErrDuplicatePeer at Start. The Manager refuses to mask the
+// wiring bug.
+func TestManager_DuplicatePeerNamesRejected(t *testing.T) {
+	t.Parallel()
+	configs := []diameter.PeerConfig{
+		{Name: "p1", Host: "h", Port: 3868, OriginHost: "oh", OriginRealm: "or"},
+		{Name: "p1", Host: "h", Port: 3868, OriginHost: "oh", OriginRealm: "or"},
+	}
+	m, _ := withFakes(t, configs)
+	err := m.Start(context.Background())
+	if !errors.Is(err, ErrDuplicatePeer) {
+		t.Errorf("Start err = %v; want ErrDuplicatePeer", err)
+	}
+}
+
+// Test 9 — Start is single-shot: a second Start returns
+// ErrAlreadyStarted.
+func TestManager_StartSingleShot(t *testing.T) {
+	t.Parallel()
+	m, _ := withFakes(t, []diameter.PeerConfig{
+		{Name: "p1", Host: "h", Port: 3868, OriginHost: "oh", OriginRealm: "or"},
+	})
+	if err := m.Start(context.Background()); err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	defer m.Stop()
+	if err := m.Start(context.Background()); !errors.Is(err, ErrAlreadyStarted) {
+		t.Errorf("second Start err = %v; want ErrAlreadyStarted", err)
+	}
+}
+
+// Test 10 — Connect on an unstarted manager returns ErrNotStarted.
+func TestManager_OperationsBeforeStart(t *testing.T) {
+	t.Parallel()
+	m, _ := withFakes(t, []diameter.PeerConfig{
+		{Name: "p1", Host: "h", Port: 3868, OriginHost: "oh", OriginRealm: "or"},
+	})
+	if err := m.Connect("p1"); !errors.Is(err, ErrNotStarted) {
+		t.Errorf("Connect before Start err = %v; want ErrNotStarted", err)
+	}
+	if err := m.Disconnect("p1"); !errors.Is(err, ErrNotStarted) {
+		t.Errorf("Disconnect before Start err = %v; want ErrNotStarted", err)
+	}
+	if _, err := m.Get("p1"); !errors.Is(err, ErrNotStarted) {
+		t.Errorf("Get before Start err = %v; want ErrNotStarted", err)
+	}
+}
+
+// Test 11 — provider error halts Start and the manager remains
+// fresh-construct-equivalent.
+func TestManager_ProviderErrorHaltsStart(t *testing.T) {
+	t.Parallel()
+	provErr := errors.New("provider boom")
+	m := New(dict.Default, errProvider{err: provErr})
+	err := m.Start(context.Background())
+	if !errors.Is(err, provErr) {
+		t.Errorf("Start err = %v; want wrapped provider error", err)
+	}
+	// The manager should be retry-able after a provider failure.
+	m2 := New(dict.Default, SlicePeerProvider{Configs: nil})
+	if err := m2.Start(context.Background()); err != nil {
+		t.Errorf("Start on empty provider: %v", err)
+	}
+	defer m2.Stop()
+}
+
+type errProvider struct{ err error }
+
+func (e errProvider) ListPeers(_ context.Context) ([]diameter.PeerConfig, error) {
+	return nil, e.err
+}
+
+// Integration test (AC-4 + AC-6) — wire the Manager to two
+// in-process go-diameter test peers and verify both reach
+// connected concurrently using the production conn.PeerConnection.
+func TestManager_TwoRealPeersConnectConcurrently(t *testing.T) {
+	t.Parallel()
+
+	// Spin up two independent in-process go-diameter servers.
+	srv1 := diamtest.NewServer(sm.New(testServerSettings("srv1")), dict.Default)
+	defer srv1.Close()
+	srv2 := diamtest.NewServer(sm.New(testServerSettings("srv2")), dict.Default)
+	defer srv2.Close()
+
+	host1, port1 := splitHostPort(srv1.Addr)
+	host2, port2 := splitHostPort(srv2.Addr)
+	configs := []diameter.PeerConfig{
+		{
+			Name: "p1", Host: host1, Port: port1,
+			OriginHost: "client1.test", OriginRealm: "test",
+			Transport:        diameter.TransportTCP,
+			WatchdogInterval: 100 * time.Millisecond,
+			AutoConnect:      true,
+		},
+		{
+			Name: "p2", Host: host2, Port: port2,
+			OriginHost: "client2.test", OriginRealm: "test",
+			Transport:        diameter.TransportTCP,
+			WatchdogInterval: 100 * time.Millisecond,
+			AutoConnect:      true,
+		},
+	}
+
+	// Production factory — uses conn.New for real go-diameter
+	// behaviour; verifies the manager wires PeerConfig through to
+	// the connection layer correctly.
+	m := New(dict.Default, SlicePeerProvider{Configs: configs})
+	if err := m.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer m.Stop()
+
+	// Wait for both peers to reach connected via the manager-level
+	// subscriber channel — proves the fan-out wires to both peers.
+	ch := m.Subscribe()
+	connected := map[string]bool{}
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	for !connected["p1"] || !connected["p2"] {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				t.Fatalf("manager subscriber channel closed before both peers connected; got %v", connected)
+			}
+			if ev.To == diameter.StateConnected {
+				connected[ev.PeerName] = true
+			}
+		case <-deadline.C:
+			t.Fatalf("timeout waiting for both peers to connect; got %v", connected)
+		}
+	}
+	// Each peer reports its own state independently.
+	if got, _ := m.State("p1"); got != diameter.StateConnected {
+		t.Errorf("p1 state = %v; want connected", got)
+	}
+	if got, _ := m.State("p2"); got != diameter.StateConnected {
+		t.Errorf("p2 state = %v; want connected", got)
+	}
+}
+
+// Test — the production factory delegates to conn.New (smoke test
+// guarding against an accidental regression where SetFactory is
+// applied before construction or productionFactory drifts away
+// from conn.New).
+func TestManager_ProductionFactoryProducesConnPeerConnection(t *testing.T) {
+	t.Parallel()
+	cfg := diameter.PeerConfig{
+		Name: "p1", Host: "127.0.0.1", Port: 3868,
+		OriginHost: "oh", OriginRealm: "or",
+	}
+	pc := productionFactory(cfg, dict.Default)
+	if _, ok := pc.(*conn.PeerConnection); !ok {
+		t.Errorf("productionFactory returned %T; want *conn.PeerConnection", pc)
+	}
+}
+
+// SlicePeerProvider returns a copy each call so callers cannot
+// mutate the manager's view through the slice.
+func TestSlicePeerProvider_ReturnsCopy(t *testing.T) {
+	t.Parallel()
+	p := SlicePeerProvider{Configs: []diameter.PeerConfig{{Name: "p1"}}}
+	got, err := p.ListPeers(context.Background())
+	if err != nil {
+		t.Fatalf("ListPeers: %v", err)
+	}
+	got[0].Name = "mutated"
+	got2, _ := p.ListPeers(context.Background())
+	if got2[0].Name != "p1" {
+		t.Errorf("provider was mutated through returned slice; got2[0] = %+v", got2[0])
+	}
+}
+
+// testServerSettings constructs a diam-test settings block. Mirrors
+// the helper in conn/connection_test.go.
+func testServerSettings(originHost string) *sm.Settings {
+	return &sm.Settings{
+		OriginHost:  datatype.DiameterIdentity(originHost),
+		OriginRealm: datatype.DiameterIdentity("test"),
+		VendorID:    13,
+		ProductName: "go-diameter-test-srv",
+	}
+}
+
+// splitHostPort matches the per-conn test helper. Local copy keeps
+// the manager package test-self-contained.
+func splitHostPort(addr string) (string, int) {
+	for i := len(addr) - 1; i >= 0; i-- {
+		if addr[i] == ':' {
+			port := 0
+			for _, c := range addr[i+1:] {
+				port = port*10 + int(c-'0')
+			}
+			return addr[:i], port
+		}
+	}
+	return addr, 0
+}

--- a/internal/diameter/manager/storeprovider.go
+++ b/internal/diameter/manager/storeprovider.go
@@ -1,0 +1,138 @@
+package manager
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/eddiecarpenter/ocs-testbench/internal/diameter"
+	"github.com/eddiecarpenter/ocs-testbench/internal/store"
+)
+
+// StoreLister is the slice of internal/store.Store the manager
+// actually consumes. Defined as its own interface here so the
+// adapter does not pull in the full Store interface — and so tests
+// can pass a mock that satisfies just this method shape.
+type StoreLister interface {
+	ListPeers(ctx context.Context) ([]store.Peer, error)
+}
+
+// StorePeerProvider adapts the production internal/store.Store to
+// the manager's PeerProvider interface.
+//
+// Each peer row's JSONB body is decoded into the PeerInput shape
+// the openapi schema commits to (api/openapi.yaml `PeerInput` block)
+// and projected onto a diameter.PeerConfig. The body is treated as
+// a contract — the adapter reads what is there and never writes
+// fields that the publisher (the REST layer) did not send.
+//
+// The adapter does NOT touch SQL directly — it goes through the
+// Store interface, mirroring dictionary.StoreSource. This preserves
+// the §14 core-separation invariant: the diameter package family
+// depends on internal/store via interface, not on a database
+// driver.
+type StorePeerProvider struct {
+	store StoreLister
+}
+
+// NewStorePeerProvider constructs a StorePeerProvider bound to the
+// given store. Panics on a nil store — wiring the manager against a
+// nil store is a programming error and should fail loudly at
+// startup, not silently when ListPeers is called.
+func NewStorePeerProvider(s StoreLister) *StorePeerProvider {
+	if s == nil {
+		panic("manager.NewStorePeerProvider: store must not be nil")
+	}
+	return &StorePeerProvider{store: s}
+}
+
+// peerBody is the on-disk JSONB shape of a peer row's body column.
+// The field names match the openapi `PeerInput` schema verbatim so
+// the adapter can decode any peer the REST layer (or any other
+// well-behaved publisher) wrote without translation. New fields
+// added to the openapi schema can be picked up here without changing
+// the contract — the json decoder ignores unknown fields by default.
+//
+// Note: this struct is the projection of an existing contract, not a
+// new one. Per the framework's Contract Rules, modifying any field
+// here without explicit approval is a contract change.
+type peerBody struct {
+	// Name is duplicated in the row's name column; we tolerate the
+	// duplication so a peerBody can be decoded standalone.
+	Name string `json:"name,omitempty"`
+
+	Host        string `json:"host"`
+	Port        int    `json:"port"`
+	OriginHost  string `json:"originHost"`
+	OriginRealm string `json:"originRealm"`
+	Transport   string `json:"transport"`
+
+	// WatchdogIntervalSeconds is the openapi field name; converted
+	// to time.Duration when projecting onto diameter.PeerConfig.
+	WatchdogIntervalSeconds int `json:"watchdogIntervalSeconds"`
+
+	// AutoConnect uses Go's default-zero of false when the field is
+	// absent. The openapi default is true; the adapter preserves
+	// "absent" as false rather than inventing a true the publisher
+	// did not send.
+	AutoConnect bool `json:"autoConnect"`
+}
+
+// ListPeers reads every peer row from the store, decodes each
+// body into the manager's PeerConfig shape, and returns the result.
+// Errors:
+//
+//   - Any store error is propagated as-is (callers can compare via
+//     errors.Is against the store's sentinels).
+//   - A peer whose body fails to decode aborts the whole list with
+//     an error that names the offending peer. The adapter does not
+//     fail-soft here — a malformed peer body is an integrity issue
+//     in the database that should surface as a startup failure, not
+//     a silent skip. The caller (manager.Start) treats a list error
+//     as fatal, so the operator gets a clear log line.
+func (p *StorePeerProvider) ListPeers(ctx context.Context) ([]diameter.PeerConfig, error) {
+	rows, err := p.store.ListPeers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]diameter.PeerConfig, 0, len(rows))
+	for _, row := range rows {
+		var body peerBody
+		if err := json.Unmarshal(row.Body, &body); err != nil {
+			return nil, fmt.Errorf("manager: decode peer %q body: %w", row.Name, err)
+		}
+		out = append(out, projectPeerBody(row.Name, body))
+	}
+	return out, nil
+}
+
+// projectPeerBody maps the JSONB-decoded peerBody onto the
+// diameter.PeerConfig the connection layer consumes. Centralised
+// here so the body→config mapping is a single function the tests
+// can exercise directly.
+//
+// The peer's name on the row (row.Name) is authoritative — the body
+// may carry the same string as a convenience but the row column is
+// the unique key.
+func projectPeerBody(rowName string, body peerBody) diameter.PeerConfig {
+	transport := strings.ToLower(strings.TrimSpace(body.Transport))
+	switch transport {
+	case "tcp", "":
+		transport = diameter.TransportTCP
+	case "tls":
+		transport = diameter.TransportTLS
+	}
+	wd := time.Duration(body.WatchdogIntervalSeconds) * time.Second
+	return diameter.PeerConfig{
+		Name:             rowName,
+		Host:             body.Host,
+		Port:             body.Port,
+		OriginHost:       body.OriginHost,
+		OriginRealm:      body.OriginRealm,
+		Transport:        transport,
+		WatchdogInterval: wd,
+		AutoConnect:      body.AutoConnect,
+	}
+}

--- a/internal/diameter/manager/storeprovider_test.go
+++ b/internal/diameter/manager/storeprovider_test.go
@@ -1,0 +1,177 @@
+package manager
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/eddiecarpenter/ocs-testbench/internal/diameter"
+	"github.com/eddiecarpenter/ocs-testbench/internal/store"
+)
+
+// stubStoreLister is a minimal StoreLister fake used by the
+// StorePeerProvider tests. It returns a fixed slice and an error
+// flag so the projection / error-propagation paths are exercised
+// without depending on an in-memory test store.
+type stubStoreLister struct {
+	rows []store.Peer
+	err  error
+}
+
+func (s stubStoreLister) ListPeers(_ context.Context) ([]store.Peer, error) {
+	return s.rows, s.err
+}
+
+// peerRow constructs a store.Peer with name = name and body = the
+// JSON-encoded value of body.
+func peerRow(t *testing.T, name string, body peerBody) store.Peer {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal peer body: %v", err)
+	}
+	return store.Peer{Name: name, Body: raw}
+}
+
+// Test 1 — happy-path projection: decoded body fields land on the
+// PeerConfig with the expected types and conversions.
+func TestStorePeerProvider_ListPeersHappyPath(t *testing.T) {
+	t.Parallel()
+	rows := []store.Peer{
+		peerRow(t, "alpha", peerBody{
+			Host: "ocs1.test", Port: 3868,
+			OriginHost: "tb-01.test.local", OriginRealm: "test.local",
+			Transport: "TCP", WatchdogIntervalSeconds: 30,
+			AutoConnect: true,
+		}),
+		peerRow(t, "bravo", peerBody{
+			Host: "ocs2.test", Port: 3869,
+			OriginHost: "tb-02.test.local", OriginRealm: "test.local",
+			Transport: "TLS", WatchdogIntervalSeconds: 60,
+			AutoConnect: false,
+		}),
+	}
+	prov := NewStorePeerProvider(stubStoreLister{rows: rows})
+	got, err := prov.ListPeers(context.Background())
+	if err != nil {
+		t.Fatalf("ListPeers: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d configs; want 2", len(got))
+	}
+
+	a := got[0]
+	if a.Name != "alpha" || a.Host != "ocs1.test" || a.Port != 3868 {
+		t.Errorf("alpha mismatch: %+v", a)
+	}
+	if a.Transport != diameter.TransportTCP {
+		t.Errorf("alpha transport = %q; want tcp", a.Transport)
+	}
+	if a.WatchdogInterval != 30*time.Second {
+		t.Errorf("alpha watchdog = %s; want 30s", a.WatchdogInterval)
+	}
+	if !a.AutoConnect {
+		t.Errorf("alpha autoConnect = false; want true")
+	}
+
+	b := got[1]
+	if b.Transport != diameter.TransportTLS {
+		t.Errorf("bravo transport = %q; want tls", b.Transport)
+	}
+	if b.AutoConnect {
+		t.Errorf("bravo autoConnect = true; want false")
+	}
+	if b.WatchdogInterval != 60*time.Second {
+		t.Errorf("bravo watchdog = %s; want 60s", b.WatchdogInterval)
+	}
+}
+
+// Test 2 — empty store: ListPeers returns empty slice with no error.
+func TestStorePeerProvider_EmptyStore(t *testing.T) {
+	t.Parallel()
+	prov := NewStorePeerProvider(stubStoreLister{rows: nil})
+	got, err := prov.ListPeers(context.Background())
+	if err != nil {
+		t.Fatalf("ListPeers: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %d; want 0", len(got))
+	}
+}
+
+// Test 3 — store error propagates as-is.
+func TestStorePeerProvider_StoreErrorPropagates(t *testing.T) {
+	t.Parallel()
+	want := errors.New("store boom")
+	prov := NewStorePeerProvider(stubStoreLister{err: want})
+	_, err := prov.ListPeers(context.Background())
+	if !errors.Is(err, want) {
+		t.Errorf("ListPeers err = %v; want %v", err, want)
+	}
+}
+
+// Test 4 — a row whose body is invalid JSON aborts the list with a
+// named error (no fail-soft).
+func TestStorePeerProvider_InvalidBodyAborts(t *testing.T) {
+	t.Parallel()
+	rows := []store.Peer{
+		peerRow(t, "good", peerBody{Host: "h", Port: 3868}),
+		{Name: "broken", Body: []byte("{ this is not json ")},
+	}
+	prov := NewStorePeerProvider(stubStoreLister{rows: rows})
+	_, err := prov.ListPeers(context.Background())
+	if err == nil {
+		t.Fatalf("ListPeers: expected decode error; got nil")
+	}
+	// The error should mention the offending peer's name so the
+	// operator can find the row.
+	if !contains(err.Error(), "broken") {
+		t.Errorf("error message %q does not mention peer name 'broken'", err.Error())
+	}
+}
+
+// Test 5 — empty transport string defaults to TCP per the openapi
+// behaviour. Same for unknown casing.
+func TestStorePeerProvider_TransportDefaulting(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		raw  string
+		want string
+	}{
+		{"", diameter.TransportTCP},
+		{"TCP", diameter.TransportTCP},
+		{"tcp", diameter.TransportTCP},
+		{"TLS", diameter.TransportTLS},
+		{"tls", diameter.TransportTLS},
+	}
+	for _, tc := range cases {
+		got := projectPeerBody("p", peerBody{Transport: tc.raw})
+		if got.Transport != tc.want {
+			t.Errorf("transport %q → %q; want %q", tc.raw, got.Transport, tc.want)
+		}
+	}
+}
+
+// Test 6 — NewStorePeerProvider panics on nil store.
+func TestStorePeerProvider_NilStorePanics(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic; got nil")
+		}
+	}()
+	NewStorePeerProvider(nil)
+}
+
+// contains is a tiny helper to assert substring presence without
+// importing strings just for one check.
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/diameter/manager/subscribers.go
+++ b/internal/diameter/manager/subscribers.go
@@ -1,0 +1,112 @@
+package manager
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/eddiecarpenter/ocs-testbench/internal/diameter"
+	"github.com/eddiecarpenter/ocs-testbench/internal/logging"
+)
+
+// subscriberBufferSize is the per-subscriber channel capacity for
+// manager-level subscribers. The fan-out interleaves events from
+// every peer so the burst size is N peers × per-peer burst — sized
+// generously to absorb a coordinated reconnect storm without
+// dropping events. A subscriber that cannot keep up loses the
+// oldest event with a logged WARN, mirroring the per-connection
+// fan-out policy.
+const subscriberBufferSize = 64
+
+// subscriberSet tracks the live manager-level subscribers. Mirrors
+// conn/state.go's subscriberSet semantics, with a bigger default
+// channel buffer because the manager fans out from N peers onto a
+// single channel.
+type subscriberSet struct {
+	mu       sync.Mutex
+	channels map[chan diameter.StateEvent]struct{}
+}
+
+// newSubscriberSet constructs an empty set. Allocation lives behind
+// a constructor so map-initialisation conventions are uniform with
+// the rest of the package.
+func newSubscriberSet() *subscriberSet {
+	return &subscriberSet{channels: map[chan diameter.StateEvent]struct{}{}}
+}
+
+// add registers a new subscriber and returns the read end.
+func (s *subscriberSet) add() <-chan diameter.StateEvent {
+	ch := make(chan diameter.StateEvent, subscriberBufferSize)
+	s.mu.Lock()
+	s.channels[ch] = struct{}{}
+	s.mu.Unlock()
+	return ch
+}
+
+// remove unregisters a subscriber and closes its channel.
+// Idempotent — a second remove on the same channel is a no-op.
+func (s *subscriberSet) remove(ch <-chan diameter.StateEvent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for c := range s.channels {
+		if c == ch {
+			delete(s.channels, c)
+			close(c)
+			return
+		}
+	}
+}
+
+// closeAll closes every registered subscriber and clears the set.
+func (s *subscriberSet) closeAll() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for c := range s.channels {
+		close(c)
+	}
+	s.channels = map[chan diameter.StateEvent]struct{}{}
+}
+
+// count returns the number of live subscribers. Used by tests.
+func (s *subscriberSet) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.channels)
+}
+
+// emit fans one StateEvent out to every subscriber. A subscriber
+// whose channel is full has the oldest event dropped (oldest-drop)
+// and the new event delivered, with a WARN log line so operators
+// see slow subscribers in their telemetry. The producer never
+// blocks.
+func (s *subscriberSet) emit(ev diameter.StateEvent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for ch := range s.channels {
+		select {
+		case ch <- ev:
+		default:
+			// Drop the oldest cached event and retry once.
+			select {
+			case <-ch:
+			default:
+			}
+			select {
+			case ch <- ev:
+			default:
+				logging.Warn(
+					"manager: state-event subscriber overflow; dropping new event",
+					"peer", ev.PeerName,
+					"from", ev.From.String(),
+					"to", ev.To.String(),
+				)
+			}
+		}
+	}
+}
+
+// sortStrings is a tiny helper around sort.Strings so the manager's
+// public Names() returns a deterministic order without the call site
+// reaching into the sort package.
+func sortStrings(s []string) {
+	sort.Strings(s)
+}

--- a/internal/diameter/messaging/cca_decoder.go
+++ b/internal/diameter/messaging/cca_decoder.go
@@ -1,0 +1,163 @@
+package messaging
+
+import (
+	"github.com/fiorix/go-diameter/v4/diam"
+	"github.com/fiorix/go-diameter/v4/diam/avp"
+	"github.com/fiorix/go-diameter/v4/diam/datatype"
+)
+
+// DecodeCCAMessage projects an incoming *diam.Message onto a
+// *CCA. The decoder is permissive — fields that are absent leave
+// the corresponding *CCA field at its zero value; the decoder
+// does not validate the message against an RFC schema (the
+// dictionary already did that at parse time).
+//
+// FUIAction is the message-level Final-Unit-Indication's action
+// when present; -1 indicates absent. MSCC blocks each carry their
+// own per-MSCC FUIAction.
+func DecodeCCAMessage(m *diam.Message) (*CCA, error) {
+	if m == nil {
+		return nil, ErrInvalidCCR // reuse — nil input is a caller bug
+	}
+	cca := &CCA{
+		Raw:       m,
+		FUIAction: -1, // sentinel: "no top-level FUI"
+	}
+
+	if a, err := m.FindAVP(avp.SessionID, 0); err == nil {
+		if v, ok := a.Data.(datatype.UTF8String); ok {
+			cca.SessionID = string(v)
+		}
+	}
+	if a, err := m.FindAVP(avp.OriginHost, 0); err == nil {
+		if v, ok := a.Data.(datatype.DiameterIdentity); ok {
+			cca.OriginHost = string(v)
+		}
+	}
+	if a, err := m.FindAVP(avp.OriginRealm, 0); err == nil {
+		if v, ok := a.Data.(datatype.DiameterIdentity); ok {
+			cca.OriginRealm = string(v)
+		}
+	}
+	if a, err := m.FindAVP(avp.AuthApplicationID, 0); err == nil {
+		if v, ok := a.Data.(datatype.Unsigned32); ok {
+			cca.AuthApplicationID = uint32(v)
+		}
+	}
+	if a, err := m.FindAVP(avp.ResultCode, 0); err == nil {
+		if v, ok := a.Data.(datatype.Unsigned32); ok {
+			cca.ResultCode = uint32(v)
+		}
+	}
+	if a, err := m.FindAVP(avp.CCRequestType, 0); err == nil {
+		if v, ok := a.Data.(datatype.Enumerated); ok {
+			cca.CCRequestType = uint32(v)
+		}
+	}
+	if a, err := m.FindAVP(avp.CCRequestNumber, 0); err == nil {
+		if v, ok := a.Data.(datatype.Unsigned32); ok {
+			cca.CCRequestNumber = uint32(v)
+		}
+	}
+	if a, err := m.FindAVP(avp.ValidityTime, 0); err == nil {
+		// Top-level Validity-Time only — the FindAVP API does
+		// not walk into MSCC sub-trees by default; per-MSCC
+		// Validity-Time is read out of MSCCBlock instead.
+		if v, ok := a.Data.(datatype.Unsigned32); ok {
+			cca.ValidityTime = uint32(v)
+		}
+	}
+	if a, err := m.FindAVP(avp.FinalUnitIndication, 0); err == nil {
+		if g, ok := a.Data.(*diam.GroupedAVP); ok {
+			cca.FUIAction = readFUIAction(g)
+		}
+	}
+
+	cca.MSCC = decodeMSCCs(m)
+	return cca, nil
+}
+
+// readFUIAction extracts the Final-Unit-Action sub-AVP from a
+// Final-Unit-Indication grouped AVP, returning -1 when absent.
+func readFUIAction(g *diam.GroupedAVP) int32 {
+	for _, sub := range g.AVP {
+		if sub.Code == avp.FinalUnitAction {
+			if v, ok := sub.Data.(datatype.Enumerated); ok {
+				return int32(v)
+			}
+		}
+	}
+	return -1
+}
+
+// decodeMSCCs walks every Multiple-Services-Credit-Control AVP at
+// the message level and produces an ordered slice of MSCCBlocks.
+// Sub-fields are read by walking the grouped AVP children — the
+// decoder does not depend on dictionary metadata for the layout
+// (the structure is fixed by RFC 4006 §8.16).
+func decodeMSCCs(m *diam.Message) []MSCCBlock {
+	avps, err := m.FindAVPs(avp.MultipleServicesCreditControl, 0)
+	if err != nil || len(avps) == 0 {
+		return nil
+	}
+	out := make([]MSCCBlock, 0, len(avps))
+	for _, mscc := range avps {
+		g, ok := mscc.Data.(*diam.GroupedAVP)
+		if !ok {
+			continue
+		}
+		block := MSCCBlock{
+			Raw:       mscc,
+			FUIAction: -1,
+		}
+		for _, sub := range g.AVP {
+			switch sub.Code {
+			case avp.ServiceIdentifier:
+				if v, ok := sub.Data.(datatype.Unsigned32); ok {
+					block.ServiceIdentifier = uint32(v)
+				}
+			case avp.RatingGroup:
+				if v, ok := sub.Data.(datatype.Unsigned32); ok {
+					block.RatingGroup = uint32(v)
+				}
+			case avp.ResultCode:
+				if v, ok := sub.Data.(datatype.Unsigned32); ok {
+					block.ResultCode = uint32(v)
+				}
+			case avp.ValidityTime:
+				if v, ok := sub.Data.(datatype.Unsigned32); ok {
+					block.ValidityTime = uint32(v)
+				}
+			case avp.GrantedServiceUnit:
+				if g, ok := sub.Data.(*diam.GroupedAVP); ok {
+					block.GrantedTime, block.GrantedTotalOctets = readGrantedUnits(g)
+				}
+			case avp.FinalUnitIndication:
+				if g, ok := sub.Data.(*diam.GroupedAVP); ok {
+					block.FUIAction = readFUIAction(g)
+				}
+			}
+		}
+		out = append(out, block)
+	}
+	return out
+}
+
+// readGrantedUnits extracts CC-Time and CC-Total-Octets from a
+// Granted-Service-Unit grouped AVP, returning zero for absent
+// sub-fields.
+func readGrantedUnits(g *diam.GroupedAVP) (ccTime uint32, ccTotalOctets uint64) {
+	for _, sub := range g.AVP {
+		switch sub.Code {
+		case avp.CCTime:
+			if v, ok := sub.Data.(datatype.Unsigned32); ok {
+				ccTime = uint32(v)
+			}
+		case avp.CCTotalOctets:
+			if v, ok := sub.Data.(datatype.Unsigned64); ok {
+				ccTotalOctets = uint64(v)
+			}
+		}
+	}
+	return ccTime, ccTotalOctets
+}

--- a/internal/diameter/messaging/cca_decoder_test.go
+++ b/internal/diameter/messaging/cca_decoder_test.go
@@ -1,0 +1,185 @@
+package messaging
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/fiorix/go-diameter/v4/diam"
+	"github.com/fiorix/go-diameter/v4/diam/avp"
+	"github.com/fiorix/go-diameter/v4/diam/datatype"
+	"github.com/fiorix/go-diameter/v4/diam/dict"
+)
+
+// buildCCATestMessage assembles a CCA-shaped *diam.Message with
+// the supplied result code, validity time, FUI, and one MSCC
+// block. Used by the decoder tests.
+func buildCCATestMessage(t *testing.T, sessionID string, resultCode uint32, validity uint32, fuiAction *int32, mscc *diam.GroupedAVP) *diam.Message {
+	t.Helper()
+	m := diam.NewMessage(diam.CreditControl, 0, 4, 1, 1, dict.Default)
+	m.NewAVP(avp.SessionID, avp.Mbit, 0, datatype.UTF8String(sessionID))
+	m.NewAVP(avp.OriginHost, avp.Mbit, 0, datatype.DiameterIdentity("ocs.test"))
+	m.NewAVP(avp.OriginRealm, avp.Mbit, 0, datatype.DiameterIdentity("test.local"))
+	m.NewAVP(avp.AuthApplicationID, avp.Mbit, 0, datatype.Unsigned32(4))
+	m.NewAVP(avp.ResultCode, avp.Mbit, 0, datatype.Unsigned32(resultCode))
+	m.NewAVP(avp.CCRequestType, avp.Mbit, 0, datatype.Enumerated(CCRTypeInitial))
+	m.NewAVP(avp.CCRequestNumber, avp.Mbit, 0, datatype.Unsigned32(0))
+	if validity != 0 {
+		m.NewAVP(avp.ValidityTime, avp.Mbit, 0, datatype.Unsigned32(validity))
+	}
+	if fuiAction != nil {
+		m.NewAVP(avp.FinalUnitIndication, avp.Mbit, 0, &diam.GroupedAVP{
+			AVP: []*diam.AVP{
+				diam.NewAVP(avp.FinalUnitAction, avp.Mbit, 0, datatype.Enumerated(*fuiAction)),
+			},
+		})
+	}
+	if mscc != nil {
+		m.NewAVP(avp.MultipleServicesCreditControl, avp.Mbit, 0, mscc)
+	}
+	return m
+}
+
+// Test 1 — happy path: decoder maps every headline field.
+func TestDecodeCCAMessage_HappyPath(t *testing.T) {
+	t.Parallel()
+	m := buildCCATestMessage(t, "sess-1", 2001, 0, nil, nil)
+	cca, err := DecodeCCAMessage(m)
+	if err != nil {
+		t.Fatalf("DecodeCCAMessage: %v", err)
+	}
+	if cca.SessionID != "sess-1" {
+		t.Errorf("SessionID = %q; want sess-1", cca.SessionID)
+	}
+	if cca.OriginHost != "ocs.test" {
+		t.Errorf("OriginHost = %q; want ocs.test", cca.OriginHost)
+	}
+	if cca.ResultCode != 2001 {
+		t.Errorf("ResultCode = %d; want 2001", cca.ResultCode)
+	}
+	if cca.AuthApplicationID != 4 {
+		t.Errorf("AuthApplicationID = %d; want 4", cca.AuthApplicationID)
+	}
+	if cca.CCRequestType != CCRTypeInitial {
+		t.Errorf("CCRequestType = %d; want %d", cca.CCRequestType, CCRTypeInitial)
+	}
+	if cca.FUIAction != -1 {
+		t.Errorf("FUIAction = %d; want -1 (absent)", cca.FUIAction)
+	}
+}
+
+// Test 2 — Validity-Time present is surfaced.
+func TestDecodeCCAMessage_ValidityTime(t *testing.T) {
+	t.Parallel()
+	m := buildCCATestMessage(t, "s", 2001, 1800, nil, nil)
+	cca, err := DecodeCCAMessage(m)
+	if err != nil {
+		t.Fatalf("DecodeCCAMessage: %v", err)
+	}
+	if cca.ValidityTime != 1800 {
+		t.Errorf("ValidityTime = %d; want 1800", cca.ValidityTime)
+	}
+}
+
+// Test 3 — top-level FUI = TERMINATE is surfaced.
+func TestDecodeCCAMessage_FUITerminate(t *testing.T) {
+	t.Parallel()
+	terminate := FUIActionTerminate
+	m := buildCCATestMessage(t, "s", 2001, 0, &terminate, nil)
+	cca, err := DecodeCCAMessage(m)
+	if err != nil {
+		t.Fatalf("DecodeCCAMessage: %v", err)
+	}
+	if cca.FUIAction != FUIActionTerminate {
+		t.Errorf("FUIAction = %d; want TERMINATE (%d)", cca.FUIAction, FUIActionTerminate)
+	}
+}
+
+// Test 4 — MSCC block decoding: per-MSCC Result-Code, granted
+// units, validity, FUI.
+func TestDecodeCCAMessage_MSCCBlock(t *testing.T) {
+	t.Parallel()
+	mscc := &diam.GroupedAVP{
+		AVP: []*diam.AVP{
+			diam.NewAVP(avp.RatingGroup, avp.Mbit, 0, datatype.Unsigned32(7)),
+			diam.NewAVP(avp.ServiceIdentifier, avp.Mbit, 0, datatype.Unsigned32(13)),
+			diam.NewAVP(avp.ResultCode, avp.Mbit, 0, datatype.Unsigned32(2001)),
+			diam.NewAVP(avp.ValidityTime, avp.Mbit, 0, datatype.Unsigned32(900)),
+			diam.NewAVP(avp.GrantedServiceUnit, avp.Mbit, 0, &diam.GroupedAVP{
+				AVP: []*diam.AVP{
+					diam.NewAVP(avp.CCTime, avp.Mbit, 0, datatype.Unsigned32(60)),
+					diam.NewAVP(avp.CCTotalOctets, avp.Mbit, 0, datatype.Unsigned64(1<<20)),
+				},
+			}),
+			diam.NewAVP(avp.FinalUnitIndication, avp.Mbit, 0, &diam.GroupedAVP{
+				AVP: []*diam.AVP{
+					diam.NewAVP(avp.FinalUnitAction, avp.Mbit, 0, datatype.Enumerated(FUIActionTerminate)),
+				},
+			}),
+		},
+	}
+	m := buildCCATestMessage(t, "s", 2001, 0, nil, mscc)
+	cca, err := DecodeCCAMessage(m)
+	if err != nil {
+		t.Fatalf("DecodeCCAMessage: %v", err)
+	}
+	if len(cca.MSCC) != 1 {
+		t.Fatalf("MSCC count = %d; want 1", len(cca.MSCC))
+	}
+	b := cca.MSCC[0]
+	if b.RatingGroup != 7 {
+		t.Errorf("RatingGroup = %d; want 7", b.RatingGroup)
+	}
+	if b.ServiceIdentifier != 13 {
+		t.Errorf("ServiceIdentifier = %d; want 13", b.ServiceIdentifier)
+	}
+	if b.ResultCode != 2001 {
+		t.Errorf("Per-MSCC ResultCode = %d; want 2001", b.ResultCode)
+	}
+	if b.ValidityTime != 900 {
+		t.Errorf("ValidityTime = %d; want 900", b.ValidityTime)
+	}
+	if b.GrantedTime != 60 {
+		t.Errorf("GrantedTime = %d; want 60", b.GrantedTime)
+	}
+	if b.GrantedTotalOctets != 1<<20 {
+		t.Errorf("GrantedTotalOctets = %d; want %d", b.GrantedTotalOctets, 1<<20)
+	}
+	if b.FUIAction != FUIActionTerminate {
+		t.Errorf("Per-MSCC FUIAction = %d; want TERMINATE", b.FUIAction)
+	}
+	if b.Raw == nil {
+		t.Errorf("Raw AVP = nil; want non-nil")
+	}
+}
+
+// Test 5 — nil message rejected.
+func TestDecodeCCAMessage_NilMessage(t *testing.T) {
+	t.Parallel()
+	_, err := DecodeCCAMessage(nil)
+	if err == nil {
+		t.Errorf("nil message: expected error; got nil")
+	}
+}
+
+// Test 6 — encode-decode round trip via go-diameter
+// serialization. Goes through the full Marshal → bytes → ReadMessage
+// pipeline so the test catches regressions in either direction.
+func TestEncodeDecodeRoundtrip(t *testing.T) {
+	t.Parallel()
+	enc, err := BuildCCRMessage(dict.Default, validCCR())
+	if err != nil {
+		t.Fatalf("BuildCCRMessage: %v", err)
+	}
+	raw, err := enc.Serialize()
+	if err != nil {
+		t.Fatalf("Serialize: %v", err)
+	}
+	parsed, err := diam.ReadMessage(bytes.NewReader(raw), dict.Default)
+	if err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	// Round-tripped E2E IDs must match.
+	if parsed.Header.EndToEndID != enc.Header.EndToEndID {
+		t.Errorf("E2E mismatch: parsed=%d enc=%d", parsed.Header.EndToEndID, enc.Header.EndToEndID)
+	}
+}

--- a/internal/diameter/messaging/ccr_builder.go
+++ b/internal/diameter/messaging/ccr_builder.go
@@ -1,0 +1,118 @@
+package messaging
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/fiorix/go-diameter/v4/diam"
+	"github.com/fiorix/go-diameter/v4/diam/avp"
+	"github.com/fiorix/go-diameter/v4/diam/datatype"
+	"github.com/fiorix/go-diameter/v4/diam/dict"
+
+	"github.com/eddiecarpenter/ocs-testbench/internal/diameter"
+)
+
+// BuildCCRMessage encodes a CCR onto a *diam.Message. The caller
+// provides the dictionary parser that should be used (typically
+// dict.Default after the loader has run); the output message
+// carries that parser so it can be serialised to the wire.
+//
+// Validation:
+//
+//   - DestinationRealm must be non-empty (RFC 4006 §3.1).
+//   - ServiceContextID must be non-empty (RFC 4006 §3.1).
+//   - CCRequestType must be one of CCRTypeInitial / Update /
+//     Terminate / Event.
+//
+// Defaults the encoder applies when the corresponding field is
+// zero:
+//
+//   - SessionID — generated as "<originHost>;<unix-nanos>;<rand>".
+//   - AuthApplicationID — 4 (Credit-Control).
+//   - EventTimestamp — current time at encode time.
+//
+// The CCR's E2E and Hop-by-Hop IDs are populated by go-diameter's
+// diam.NewRequest — the encoder does not assign them; instead the
+// Sender uses them as the correlator key.
+func BuildCCRMessage(parser *dict.Parser, req *CCR) (*diam.Message, error) {
+	if parser == nil {
+		return nil, fmt.Errorf("%w: parser is nil", ErrInvalidCCR)
+	}
+	if req == nil {
+		return nil, fmt.Errorf("%w: ccr is nil", ErrInvalidCCR)
+	}
+	if strings.TrimSpace(req.DestinationRealm) == "" {
+		return nil, fmt.Errorf("%w: destination-realm is empty", ErrInvalidCCR)
+	}
+	if strings.TrimSpace(req.ServiceContextID) == "" {
+		return nil, fmt.Errorf("%w: service-context-id is empty", ErrInvalidCCR)
+	}
+	if req.CCRequestType < CCRTypeInitial || req.CCRequestType > CCRTypeEvent {
+		return nil, fmt.Errorf("%w: cc-request-type %d out of range", ErrInvalidCCR, req.CCRequestType)
+	}
+
+	auth := req.AuthApplicationID
+	if auth == 0 {
+		auth = diameter.AppIDCreditControl
+	}
+	sessionID := req.SessionID
+	if sessionID == "" {
+		sessionID = generateSessionID(req.OriginHost)
+	}
+	ts := req.EventTimestamp
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	}
+
+	m := diam.NewRequest(diam.CreditControl, auth, parser)
+
+	// Ordering follows the canonical RFC 4006 §3.1 layout. The
+	// receiver does not enforce ordering, but staying close to the
+	// AVP order in the standard makes pcap-debugging easier.
+	m.NewAVP(avp.SessionID, avp.Mbit, 0, datatype.UTF8String(sessionID))
+	m.NewAVP(avp.OriginHost, avp.Mbit, 0, datatype.DiameterIdentity(req.OriginHost))
+	m.NewAVP(avp.OriginRealm, avp.Mbit, 0, datatype.DiameterIdentity(req.OriginRealm))
+	m.NewAVP(avp.DestinationRealm, avp.Mbit, 0, datatype.DiameterIdentity(req.DestinationRealm))
+	if strings.TrimSpace(req.DestinationHost) != "" {
+		m.NewAVP(avp.DestinationHost, avp.Mbit, 0, datatype.DiameterIdentity(req.DestinationHost))
+	}
+	m.NewAVP(avp.AuthApplicationID, avp.Mbit, 0, datatype.Unsigned32(auth))
+	m.NewAVP(avp.ServiceContextID, avp.Mbit, 0, datatype.UTF8String(req.ServiceContextID))
+	m.NewAVP(avp.CCRequestType, avp.Mbit, 0, datatype.Enumerated(req.CCRequestType))
+	m.NewAVP(avp.CCRequestNumber, avp.Mbit, 0, datatype.Unsigned32(req.CCRequestNumber))
+	m.NewAVP(avp.EventTimestamp, avp.Mbit, 0, datatype.Time(ts))
+
+	// Caller-supplied AVPs trail the canonical block. The encoder
+	// does not deduplicate against the canonical AVPs above —
+	// callers are responsible for not double-supplying Session-Id
+	// etc. via ExtraAVPs. The OCS will reject duplicates with a
+	// 5xxx anyway.
+	for _, a := range req.ExtraAVPs {
+		if a == nil {
+			continue
+		}
+		m.AddAVP(a)
+	}
+
+	return m, nil
+}
+
+// generateSessionID renders an RFC 6733 §8.8-conformant Session-Id
+// of the shape "<originHost>;<unix-secs>;<unix-nanos>;<rand-hex>".
+// Falls back to a static prefix when originHost is empty.
+func generateSessionID(originHost string) string {
+	if strings.TrimSpace(originHost) == "" {
+		originHost = "ocs-testbench.local"
+	}
+	now := time.Now().UTC()
+	var randBytes [4]byte
+	_, _ = rand.Read(randBytes[:])
+	return fmt.Sprintf("%s;%d;%d;%s",
+		originHost,
+		now.Unix(),
+		now.UnixNano(),
+		hex.EncodeToString(randBytes[:]))
+}

--- a/internal/diameter/messaging/ccr_builder_test.go
+++ b/internal/diameter/messaging/ccr_builder_test.go
@@ -1,0 +1,210 @@
+package messaging
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fiorix/go-diameter/v4/diam"
+	"github.com/fiorix/go-diameter/v4/diam/avp"
+	"github.com/fiorix/go-diameter/v4/diam/datatype"
+	"github.com/fiorix/go-diameter/v4/diam/dict"
+)
+
+// validCCR returns a CCR that should encode without error.
+func validCCR() *CCR {
+	return &CCR{
+		SessionID:         "test;1234;0;abcd",
+		OriginHost:        "tb.test.local",
+		OriginRealm:       "test.local",
+		DestinationRealm:  "ocs.test.local",
+		AuthApplicationID: 4,
+		ServiceContextID:  "32251@3gpp.org",
+		CCRequestType:     CCRTypeInitial,
+		CCRequestNumber:   0,
+		EventTimestamp:    time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+// Test 1 — happy path encoding produces a Diameter request
+// with the correct command code and application id.
+func TestBuildCCRMessage_HappyPath(t *testing.T) {
+	t.Parallel()
+	m, err := BuildCCRMessage(dict.Default, validCCR())
+	if err != nil {
+		t.Fatalf("BuildCCRMessage: %v", err)
+	}
+	if m.Header.CommandCode != diam.CreditControl {
+		t.Errorf("command code = %d; want %d", m.Header.CommandCode, diam.CreditControl)
+	}
+	if m.Header.ApplicationID != 4 {
+		t.Errorf("application id = %d; want 4", m.Header.ApplicationID)
+	}
+	if m.Header.CommandFlags&diam.RequestFlag == 0 {
+		t.Errorf("RequestFlag not set on header")
+	}
+	// Spot-check that key AVPs are present.
+	for _, code := range []uint32{
+		avp.SessionID,
+		avp.OriginHost,
+		avp.OriginRealm,
+		avp.DestinationRealm,
+		avp.AuthApplicationID,
+		avp.ServiceContextID,
+		avp.CCRequestType,
+		avp.CCRequestNumber,
+		avp.EventTimestamp,
+	} {
+		if _, err := m.FindAVP(code, 0); err != nil {
+			t.Errorf("AVP code %d missing: %v", code, err)
+		}
+	}
+}
+
+// Test 2 — destination realm empty is rejected.
+func TestBuildCCRMessage_DestinationRealmRequired(t *testing.T) {
+	t.Parallel()
+	r := validCCR()
+	r.DestinationRealm = ""
+	if _, err := BuildCCRMessage(dict.Default, r); !errors.Is(err, ErrInvalidCCR) {
+		t.Errorf("err = %v; want ErrInvalidCCR", err)
+	}
+}
+
+// Test 3 — service-context-id empty is rejected.
+func TestBuildCCRMessage_ServiceContextIDRequired(t *testing.T) {
+	t.Parallel()
+	r := validCCR()
+	r.ServiceContextID = ""
+	if _, err := BuildCCRMessage(dict.Default, r); !errors.Is(err, ErrInvalidCCR) {
+		t.Errorf("err = %v; want ErrInvalidCCR", err)
+	}
+}
+
+// Test 4 — out-of-range CC-Request-Type is rejected.
+func TestBuildCCRMessage_RequestTypeRange(t *testing.T) {
+	t.Parallel()
+	for _, badType := range []uint32{0, 5, 99} {
+		r := validCCR()
+		r.CCRequestType = badType
+		if _, err := BuildCCRMessage(dict.Default, r); !errors.Is(err, ErrInvalidCCR) {
+			t.Errorf("CCRequestType=%d err = %v; want ErrInvalidCCR", badType, err)
+		}
+	}
+}
+
+// Test 5 — Session-ID auto-generated when empty.
+func TestBuildCCRMessage_SessionIDDefaulted(t *testing.T) {
+	t.Parallel()
+	r := validCCR()
+	r.SessionID = ""
+	m, err := BuildCCRMessage(dict.Default, r)
+	if err != nil {
+		t.Fatalf("BuildCCRMessage: %v", err)
+	}
+	a, err := m.FindAVP(avp.SessionID, 0)
+	if err != nil {
+		t.Fatalf("Session-Id AVP not present: %v", err)
+	}
+	v, ok := a.Data.(datatype.UTF8String)
+	if !ok {
+		t.Fatalf("Session-Id type = %T; want UTF8String", a.Data)
+	}
+	if !strings.HasPrefix(string(v), r.OriginHost) {
+		t.Errorf("Session-Id %q does not begin with origin host %q", v, r.OriginHost)
+	}
+}
+
+// Test 6 — AuthApplicationID defaults to 4 when zero.
+func TestBuildCCRMessage_AuthApplicationIDDefaulted(t *testing.T) {
+	t.Parallel()
+	r := validCCR()
+	r.AuthApplicationID = 0
+	m, err := BuildCCRMessage(dict.Default, r)
+	if err != nil {
+		t.Fatalf("BuildCCRMessage: %v", err)
+	}
+	if m.Header.ApplicationID != 4 {
+		t.Errorf("application id = %d; want 4", m.Header.ApplicationID)
+	}
+	a, err := m.FindAVP(avp.AuthApplicationID, 0)
+	if err != nil {
+		t.Fatalf("Auth-Application-Id AVP missing: %v", err)
+	}
+	if v, ok := a.Data.(datatype.Unsigned32); !ok || uint32(v) != 4 {
+		t.Errorf("Auth-Application-Id AVP = %v; want 4", a.Data)
+	}
+}
+
+// Test 7 — Destination-Host included when present, omitted when
+// empty.
+func TestBuildCCRMessage_DestinationHostOptional(t *testing.T) {
+	t.Parallel()
+	r := validCCR()
+	r.DestinationHost = "ocs-edge.test.local"
+	m, err := BuildCCRMessage(dict.Default, r)
+	if err != nil {
+		t.Fatalf("BuildCCRMessage: %v", err)
+	}
+	if _, err := m.FindAVP(avp.DestinationHost, 0); err != nil {
+		t.Errorf("Destination-Host AVP missing: %v", err)
+	}
+
+	r2 := validCCR()
+	m2, err := BuildCCRMessage(dict.Default, r2)
+	if err != nil {
+		t.Fatalf("BuildCCRMessage 2: %v", err)
+	}
+	if _, err := m2.FindAVP(avp.DestinationHost, 0); err == nil {
+		t.Errorf("Destination-Host AVP unexpectedly present in default-config CCR")
+	}
+}
+
+// Test 8 — ExtraAVPs are appended verbatim.
+func TestBuildCCRMessage_ExtraAVPsAppended(t *testing.T) {
+	t.Parallel()
+	r := validCCR()
+	r.ExtraAVPs = []*diam.AVP{
+		diam.NewAVP(avp.UserName, avp.Mbit, 0, datatype.UTF8String("alice")),
+	}
+	m, err := BuildCCRMessage(dict.Default, r)
+	if err != nil {
+		t.Fatalf("BuildCCRMessage: %v", err)
+	}
+	a, err := m.FindAVP(avp.UserName, 0)
+	if err != nil {
+		t.Fatalf("UserName AVP missing: %v", err)
+	}
+	if v, ok := a.Data.(datatype.UTF8String); !ok || string(v) != "alice" {
+		t.Errorf("UserName AVP data = %v; want \"alice\"", a.Data)
+	}
+}
+
+// Test 9 — distinct E2E IDs across consecutive builds (defensive
+// against go-diameter regressions).
+func TestBuildCCRMessage_DistinctE2EIDs(t *testing.T) {
+	t.Parallel()
+	m1, err := BuildCCRMessage(dict.Default, validCCR())
+	if err != nil {
+		t.Fatalf("BuildCCRMessage 1: %v", err)
+	}
+	m2, err := BuildCCRMessage(dict.Default, validCCR())
+	if err != nil {
+		t.Fatalf("BuildCCRMessage 2: %v", err)
+	}
+	if m1.Header.EndToEndID == m2.Header.EndToEndID {
+		t.Errorf("identical end-to-end IDs: %d", m1.Header.EndToEndID)
+	}
+}
+
+// Test 10 — nil parser / nil ccr rejected.
+func TestBuildCCRMessage_NilGuards(t *testing.T) {
+	t.Parallel()
+	if _, err := BuildCCRMessage(nil, validCCR()); !errors.Is(err, ErrInvalidCCR) {
+		t.Errorf("nil parser: err = %v; want ErrInvalidCCR", err)
+	}
+	if _, err := BuildCCRMessage(dict.Default, nil); !errors.Is(err, ErrInvalidCCR) {
+		t.Errorf("nil ccr: err = %v; want ErrInvalidCCR", err)
+	}
+}

--- a/internal/diameter/messaging/doc.go
+++ b/internal/diameter/messaging/doc.go
@@ -1,0 +1,32 @@
+// Package messaging implements the Gy credit-control message
+// surface of the Diameter stack.
+//
+// Three deliverables:
+//
+//   - CCR (Credit-Control-Request) and CCA
+//     (Credit-Control-Answer) Go-native types that hold the fields
+//     scenarios and the engine layer typically need (Session-Id,
+//     Origin-Host, Origin-Realm, Destination-Realm, Auth-
+//     Application-Id, Service-Context-Id, CC-Request-Type / Number,
+//     Subscription-Id, MSCC blocks, …) plus a slice of arbitrary
+//     extra AVPs the caller can inject.
+//
+//   - Encoder (BuildCCRMessage) and decoder (DecodeCCAMessage)
+//     for the wire format. Encoding uses the package-level
+//     dictionary singleton (dict.Default after the loader has run);
+//     decoding produces a *CCA shaped for both engine-layer
+//     consumption and the protocol-mandated behaviour layer
+//     (task 5).
+//
+//   - Sender — the §14 Sender contract (`Send(ctx, peerName, ccr)
+//     -> (*CCA, error)`). The concrete implementation resolves
+//     `peerName` via the manager.Manager, encodes the CCR,
+//     correlates the CCA response by end-to-end / hop-by-hop ID,
+//     and decodes it. A peer in `disconnected` state fails fast
+//     with diameter.ErrPeerNotConnected — no queueing, no retry.
+//
+// The messaging package does NOT implement protocol-mandated CCA
+// behaviour (FUI-TERMINATE → CCR-T, Validity-Time → CCR-U, 5xxx
+// → terminate). Those live in internal/diameter/protocol (task 5)
+// as a Sender decorator over this package's concrete sender.
+package messaging

--- a/internal/diameter/messaging/sender.go
+++ b/internal/diameter/messaging/sender.go
@@ -1,0 +1,271 @@
+package messaging
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/fiorix/go-diameter/v4/diam"
+
+	"github.com/eddiecarpenter/ocs-testbench/internal/diameter"
+	"github.com/eddiecarpenter/ocs-testbench/internal/diameter/manager"
+	"github.com/eddiecarpenter/ocs-testbench/internal/logging"
+)
+
+// Sender is the §14 abstraction the engine and any other caller
+// uses to send a CCR and obtain the corresponding CCA. Returning
+// an error means the request did not produce a CCA — the wire was
+// not touched (peer disconnected) or the connection dropped during
+// the wait.
+//
+// Implementations MUST be safe for concurrent use.
+type Sender interface {
+	// Send blocks until the CCA correlated to req's E2E ID
+	// arrives or ctx is cancelled. Returns
+	// diameter.ErrPeerNotConnected when peerName is unknown or
+	// in disconnected state — fail-fast per AC-14.
+	Send(ctx context.Context, peerName string, req *CCR) (*CCA, error)
+}
+
+// Resolver is the slice of manager.Manager the Sender consumes.
+// Defined as its own interface here so tests can supply a mock
+// without spinning up the full manager.
+type Resolver interface {
+	// Get returns the PeerConnection bound to peerName, or an
+	// error — typically manager.ErrUnknownPeer.
+	Get(name string) (manager.PeerConnection, error)
+}
+
+// peerCorrelator is the per-peer registry of in-flight CCRs
+// keyed by end-to-end ID. The handler installed on the
+// PeerConnection consults this map when a CCA arrives and
+// dispatches the message onto the matching channel.
+//
+// One peerCorrelator per peer (the Sender holds a sync.Map keyed
+// by peer name). The handler sees the *PeerConnection it is
+// installed on, but our handler closure captures the
+// peerCorrelator pointer at registration time so the dispatch
+// path doesn't need a back-pointer.
+type peerCorrelator struct {
+	mu      sync.Mutex
+	pending map[uint32]chan *diam.Message
+}
+
+func newPeerCorrelator() *peerCorrelator {
+	return &peerCorrelator{pending: map[uint32]chan *diam.Message{}}
+}
+
+// register adds a pending request keyed by e2eID. The returned
+// channel is closed when the connection drops, or receives one
+// message when the matching CCA arrives.
+func (c *peerCorrelator) register(e2eID uint32) chan *diam.Message {
+	ch := make(chan *diam.Message, 1)
+	c.mu.Lock()
+	c.pending[e2eID] = ch
+	c.mu.Unlock()
+	return ch
+}
+
+// deregister removes a pending entry without closing its channel.
+// Used by the Send path when ctx is cancelled and the caller
+// wants to abandon the wait.
+func (c *peerCorrelator) deregister(e2eID uint32) {
+	c.mu.Lock()
+	delete(c.pending, e2eID)
+	c.mu.Unlock()
+}
+
+// dispatch is invoked by the CCA handler with an incoming
+// message. Looks up the matching pending entry and forwards the
+// message; if no entry exists (the request timed out / was
+// cancelled before the response arrived) the message is dropped
+// with a WARN log.
+func (c *peerCorrelator) dispatch(m *diam.Message) {
+	if m == nil || m.Header == nil {
+		return
+	}
+	e2eID := m.Header.EndToEndID
+	c.mu.Lock()
+	ch, ok := c.pending[e2eID]
+	if ok {
+		delete(c.pending, e2eID)
+	}
+	c.mu.Unlock()
+	if !ok {
+		logging.Warn(
+			"messaging: dropping CCA with no matching pending request",
+			"end_to_end_id", e2eID,
+		)
+		return
+	}
+	// Non-blocking send — the channel is buffered (cap 1) and only
+	// one message is ever delivered per e2eID, so this select is
+	// belt-and-braces against a buggy double-dispatch.
+	select {
+	case ch <- m:
+	default:
+	}
+}
+
+// closeAll closes every pending channel. Called by the Sender
+// when the peer disconnects so blocked Send calls return cleanly
+// with ErrCorrelatorClosed.
+func (c *peerCorrelator) closeAll() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for id, ch := range c.pending {
+		close(ch)
+		delete(c.pending, id)
+	}
+}
+
+// concreteSender is the production implementation of Sender.
+// Constructed via NewSender.
+type concreteSender struct {
+	resolver Resolver
+
+	mu       sync.Mutex
+	perPeer  map[string]*peerCorrelator
+	stateSub map[string]<-chan diameter.StateEvent
+}
+
+// NewSender constructs a Sender that resolves peers via the
+// supplied Resolver (typically a *manager.Manager). Panics on a
+// nil resolver — wiring a Sender against a nil manager is a
+// programming error.
+func NewSender(r Resolver) Sender {
+	if r == nil {
+		panic("messaging.NewSender: resolver must not be nil")
+	}
+	return &concreteSender{
+		resolver: r,
+		perPeer:  map[string]*peerCorrelator{},
+		stateSub: map[string]<-chan diameter.StateEvent{},
+	}
+}
+
+// Send writes the CCR to the named peer and blocks until the
+// matching CCA arrives, ctx is cancelled, or the peer drops.
+//
+// AC-14 enforcement: when the peer is in any non-connected state
+// at the moment Send is called, the call returns
+// diameter.ErrPeerNotConnected immediately without writing
+// anything to the wire. The check is point-in-time — a peer that
+// drops between the check and the write surfaces as
+// ErrCorrelatorClosed when the close-all cascade fires.
+func (s *concreteSender) Send(ctx context.Context, peerName string, req *CCR) (*CCA, error) {
+	pc, err := s.resolver.Get(peerName)
+	if err != nil {
+		return nil, fmt.Errorf("messaging: resolve peer %q: %w", peerName, err)
+	}
+	if pc.State() != diameter.StateConnected {
+		return nil, fmt.Errorf("%w: peer %q is %s",
+			diameter.ErrPeerNotConnected, peerName, pc.State())
+	}
+	conn := pc.Conn()
+	if conn == nil {
+		// State drifted between the State() and Conn() reads. The
+		// connection laid out by conn.PeerConnection guarantees
+		// activeConn is non-nil while StateConnected, but we
+		// defend belt-and-braces.
+		return nil, fmt.Errorf("%w: peer %q connection went away",
+			diameter.ErrPeerNotConnected, peerName)
+	}
+
+	// Pre-fill peer-scoped fields from the connection's PeerConfig
+	// so the encoder produces a well-formed CCR without forcing
+	// every caller to re-state the local identity.
+	cfg := pc.Config()
+	enriched := *req
+	if enriched.OriginHost == "" {
+		enriched.OriginHost = cfg.OriginHost
+	}
+	if enriched.OriginRealm == "" {
+		enriched.OriginRealm = cfg.OriginRealm
+	}
+	if enriched.DestinationRealm == "" {
+		enriched.DestinationRealm = cfg.OriginRealm
+	}
+
+	correlator := s.correlatorFor(peerName, pc)
+
+	msg, err := BuildCCRMessage(conn.Dictionary(), &enriched)
+	if err != nil {
+		return nil, fmt.Errorf("messaging: build CCR for peer %q: %w", peerName, err)
+	}
+
+	// Capture the correlator key before sending. diam.NewRequest
+	// has already populated EndToEndID and HopByHopID inside
+	// BuildCCRMessage; we simply read them out.
+	e2eID := msg.Header.EndToEndID
+	respCh := correlator.register(e2eID)
+
+	if _, err := msg.WriteTo(conn); err != nil {
+		correlator.deregister(e2eID)
+		return nil, fmt.Errorf("messaging: write CCR to peer %q: %w", peerName, err)
+	}
+
+	select {
+	case resp, ok := <-respCh:
+		if !ok {
+			return nil, fmt.Errorf("messaging: peer %q dropped during request: %w",
+				peerName, ErrCorrelatorClosed)
+		}
+		return DecodeCCAMessage(resp)
+	case <-ctx.Done():
+		correlator.deregister(e2eID)
+		return nil, ctx.Err()
+	}
+}
+
+// correlatorFor returns the per-peer correlator, lazily creating
+// one and registering the CCA handler on the connection on first
+// use. Subsequent calls return the existing instance.
+func (s *concreteSender) correlatorFor(peerName string, pc manager.PeerConnection) *peerCorrelator {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if c, ok := s.perPeer[peerName]; ok {
+		return c
+	}
+	c := newPeerCorrelator()
+	s.perPeer[peerName] = c
+
+	// Capture the correlator pointer in the closure so the
+	// handler's dispatch path doesn't need to look the peer up.
+	pc.HandleFunc("CCA", func(_ diam.Conn, m *diam.Message) {
+		c.dispatch(m)
+	})
+
+	// Watch the peer's state so we can close pending channels on
+	// drop. The state subscription runs in its own goroutine —
+	// one per peer — until the connection's subscriber channel
+	// is closed (PeerConnection.Disconnect tears it down).
+	stateCh := pc.Subscribe()
+	s.stateSub[peerName] = stateCh
+	go s.watchPeerState(peerName, stateCh, c)
+
+	return c
+}
+
+// watchPeerState consumes state transitions for one peer and
+// closes pending correlator entries every time the peer leaves
+// StateConnected. This unblocks any Send() call that was
+// waiting for a response when the connection dropped.
+func (s *concreteSender) watchPeerState(peerName string, ch <-chan diameter.StateEvent, c *peerCorrelator) {
+	for ev := range ch {
+		if ev.From == diameter.StateConnected && ev.To != diameter.StateConnected {
+			c.closeAll()
+		}
+	}
+	// Channel closed — final cleanup.
+	c.closeAll()
+	s.mu.Lock()
+	delete(s.stateSub, peerName)
+	s.mu.Unlock()
+}
+
+// noOpDiscard is a sentinel error variable that lets Sender
+// callers branch on errors.Is(err, diameter.ErrPeerNotConnected)
+// for both the resolve and not-connected paths in tests.
+var _ = errors.Is

--- a/internal/diameter/messaging/sender_test.go
+++ b/internal/diameter/messaging/sender_test.go
@@ -1,0 +1,318 @@
+package messaging
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/fiorix/go-diameter/v4/diam"
+	"github.com/fiorix/go-diameter/v4/diam/avp"
+	"github.com/fiorix/go-diameter/v4/diam/datatype"
+	"github.com/fiorix/go-diameter/v4/diam/diamtest"
+	"github.com/fiorix/go-diameter/v4/diam/dict"
+	"github.com/fiorix/go-diameter/v4/diam/sm"
+
+	"github.com/eddiecarpenter/ocs-testbench/internal/diameter"
+	"github.com/eddiecarpenter/ocs-testbench/internal/diameter/conn"
+	"github.com/eddiecarpenter/ocs-testbench/internal/diameter/manager"
+)
+
+// fakeResolver is a tiny manager.Resolver substitute for tests
+// that do not need to spin up the full Manager.
+type fakeResolver struct {
+	peers map[string]manager.PeerConnection
+	err   error
+}
+
+func (f fakeResolver) Get(name string) (manager.PeerConnection, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	pc, ok := f.peers[name]
+	if !ok {
+		return nil, manager.ErrUnknownPeer
+	}
+	return pc, nil
+}
+
+// fakePeer is a minimal manager.PeerConnection used to exercise
+// the Sender's disconnected-peer guard. Holds a fixed state and a
+// nil diam.Conn.
+type fakePeer struct {
+	cfg   diameter.PeerConfig
+	state diameter.ConnectionState
+	subs  chan diameter.StateEvent
+	once  sync.Once
+}
+
+func (f *fakePeer) Config() diameter.PeerConfig             { return f.cfg }
+func (f *fakePeer) State() diameter.ConnectionState         { return f.state }
+func (f *fakePeer) Conn() diam.Conn                         { return nil }
+func (f *fakePeer) Connect(_ context.Context) error         { return nil }
+func (f *fakePeer) Disconnect()                             {}
+func (f *fakePeer) HandleFunc(_ string, _ diam.HandlerFunc) {}
+func (f *fakePeer) Subscribe() <-chan diameter.StateEvent {
+	f.once.Do(func() { f.subs = make(chan diameter.StateEvent, 4) })
+	return f.subs
+}
+
+// Test 1 — Sender returns ErrPeerNotConnected synchronously when
+// the peer is disconnected. The wire is not touched.
+func TestSender_DisconnectedPeerFailsFast(t *testing.T) {
+	t.Parallel()
+	pc := &fakePeer{
+		cfg:   diameter.PeerConfig{Name: "p1", OriginHost: "tb", OriginRealm: "test"},
+		state: diameter.StateDisconnected,
+	}
+	res := fakeResolver{peers: map[string]manager.PeerConnection{"p1": pc}}
+	s := NewSender(res)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_, err := s.Send(ctx, "p1", validCCR())
+	if !errors.Is(err, diameter.ErrPeerNotConnected) {
+		t.Errorf("Send err = %v; want diameter.ErrPeerNotConnected", err)
+	}
+}
+
+// Test 2 — Sender returns the resolver's error verbatim when the
+// peer is unknown.
+func TestSender_UnknownPeerSurfaces(t *testing.T) {
+	t.Parallel()
+	res := fakeResolver{peers: map[string]manager.PeerConnection{}}
+	s := NewSender(res)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_, err := s.Send(ctx, "missing", validCCR())
+	if !errors.Is(err, manager.ErrUnknownPeer) {
+		t.Errorf("Send err = %v; want manager.ErrUnknownPeer", err)
+	}
+}
+
+// Test 3 — NewSender(nil) panics.
+func TestNewSender_NilResolverPanics(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic on nil resolver")
+		}
+	}()
+	NewSender(nil)
+}
+
+// ---------------------------------------------------------------------
+// In-process round-trip tests with a real go-diameter peer.
+// ---------------------------------------------------------------------
+
+// ccaEchoServer spins up a diamtest server that responds to every
+// incoming CCR with a canned CCA carrying the supplied result code,
+// the original session id, and the original e2e/hop ids.
+func ccaEchoServer(t *testing.T, originHost string, resultCode uint32) (*diamtest.Server, string) {
+	t.Helper()
+	settings := &sm.Settings{
+		OriginHost:  datatype.DiameterIdentity(originHost),
+		OriginRealm: datatype.DiameterIdentity("test"),
+		VendorID:    13,
+		ProductName: "go-diameter-cca-echo",
+	}
+	mgr := sm.New(settings)
+	mgr.HandleFunc("CCR", func(c diam.Conn, m *diam.Message) {
+		// Build the answer with the same E2E and Hop-by-Hop IDs.
+		a := m.Answer(resultCode)
+		// Echo Session-Id verbatim.
+		if sid, err := m.FindAVP(avp.SessionID, 0); err == nil {
+			a.AddAVP(sid)
+		}
+		a.NewAVP(avp.OriginHost, avp.Mbit, 0, datatype.DiameterIdentity(originHost))
+		a.NewAVP(avp.OriginRealm, avp.Mbit, 0, datatype.DiameterIdentity("test"))
+		a.NewAVP(avp.AuthApplicationID, avp.Mbit, 0, datatype.Unsigned32(4))
+		// Echo CC-Request-Type / Number for round-trip correlation.
+		if rt, err := m.FindAVP(avp.CCRequestType, 0); err == nil {
+			a.AddAVP(rt)
+		}
+		if rn, err := m.FindAVP(avp.CCRequestNumber, 0); err == nil {
+			a.AddAVP(rn)
+		}
+		_, _ = a.WriteTo(c)
+	})
+	srv := diamtest.NewServer(mgr, dict.Default)
+	return srv, srv.Addr
+}
+
+// realPeerConfig builds a PeerConfig pointing at addr.
+func realPeerConfig(name, addr string) diameter.PeerConfig {
+	host, port := splitHostPort(addr)
+	return diameter.PeerConfig{
+		Name: name, Host: host, Port: port,
+		OriginHost: "tb." + name + ".test", OriginRealm: "test",
+		Transport: diameter.TransportTCP, WatchdogInterval: 100 * time.Millisecond,
+	}
+}
+
+// splitHostPort matches the helper in conn/connection_test.go and
+// manager/manager_test.go. Local copy keeps each test package
+// self-contained.
+func splitHostPort(addr string) (string, int) {
+	for i := len(addr) - 1; i >= 0; i-- {
+		if addr[i] == ':' {
+			port := 0
+			for _, c := range addr[i+1:] {
+				port = port*10 + int(c-'0')
+			}
+			return addr[:i], port
+		}
+	}
+	return addr, 0
+}
+
+// awaitConnected blocks until pc reports StateConnected or
+// timeout expires.
+func awaitConnected(t *testing.T, pc *conn.PeerConnection, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if pc.State() == diameter.StateConnected {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("peer did not reach StateConnected within %s", timeout)
+}
+
+// Test 4 — encode/decode round trip via a real in-process peer.
+func TestSender_RoundTripWithEchoPeer(t *testing.T) {
+	t.Parallel()
+	srv, addr := ccaEchoServer(t, "ocs-echo.test", 2001)
+	defer srv.Close()
+
+	pc := conn.New(realPeerConfig("p1", addr), dict.Default)
+	if err := pc.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer pc.Disconnect()
+	awaitConnected(t, pc, 5*time.Second)
+
+	// Wire the Sender directly to a fixed-resolver pointing at this
+	// PeerConnection. The fake-resolver path is exercised by tests
+	// 1–2; this is the live-wire path.
+	res := fakeResolver{peers: map[string]manager.PeerConnection{"p1": pc}}
+	s := NewSender(res)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cca, err := s.Send(ctx, "p1", validCCR())
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if cca.ResultCode != 2001 {
+		t.Errorf("ResultCode = %d; want 2001", cca.ResultCode)
+	}
+	if cca.SessionID != validCCR().SessionID {
+		t.Errorf("SessionID echoed = %q; want %q", cca.SessionID, validCCR().SessionID)
+	}
+	if cca.CCRequestType != CCRTypeInitial {
+		t.Errorf("CCRequestType = %d; want %d", cca.CCRequestType, CCRTypeInitial)
+	}
+}
+
+// Test 5 — concurrent Send calls all receive their correct CCAs
+// (E2E correlation works for parallel requests).
+func TestSender_ConcurrentSendsCorrelateByE2EID(t *testing.T) {
+	t.Parallel()
+	srv, addr := ccaEchoServer(t, "ocs-conc.test", 2001)
+	defer srv.Close()
+
+	pc := conn.New(realPeerConfig("p1", addr), dict.Default)
+	if err := pc.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer pc.Disconnect()
+	awaitConnected(t, pc, 5*time.Second)
+
+	res := fakeResolver{peers: map[string]manager.PeerConnection{"p1": pc}}
+	s := NewSender(res)
+
+	const N = 8
+	var (
+		wg    sync.WaitGroup
+		errCt atomic.Int32
+		okCt  atomic.Int32
+	)
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			ccr := validCCR()
+			ccr.SessionID = "" // force unique session ids
+			cca, err := s.Send(ctx, "p1", ccr)
+			if err != nil {
+				errCt.Add(1)
+				return
+			}
+			if cca.ResultCode != 2001 {
+				errCt.Add(1)
+				return
+			}
+			okCt.Add(1)
+		}()
+	}
+	wg.Wait()
+	if errCt.Load() != 0 {
+		t.Errorf("concurrent Send errors: %d/%d; want 0", errCt.Load(), N)
+	}
+	if okCt.Load() != N {
+		t.Errorf("concurrent Send successes: %d; want %d", okCt.Load(), N)
+	}
+}
+
+// Test 6 — context cancellation aborts the wait, returns ctx.Err.
+// Uses a non-responsive server (an opened but never-answering go-
+// diameter server doesn't exist — we point the connection at a
+// black-hole listener and confirm the cancellation path fires).
+//
+// Implementation: we spin up a real CCA-echo server, connect, but
+// pre-register a pending E2E ID with no-one to dispatch it; that
+// guarantees the Send is waiting on the channel when ctx is
+// cancelled.
+func TestSender_ContextCancellation(t *testing.T) {
+	t.Parallel()
+	// Spin up a real connection but use a server that DOES NOT
+	// answer CCRs — silent server.
+	settings := &sm.Settings{
+		OriginHost:  datatype.DiameterIdentity("ocs-silent.test"),
+		OriginRealm: datatype.DiameterIdentity("test"),
+		VendorID:    13,
+		ProductName: "go-diameter-silent",
+	}
+	srv := diamtest.NewServer(sm.New(settings), dict.Default)
+	defer srv.Close()
+
+	pc := conn.New(realPeerConfig("silent", srv.Addr), dict.Default)
+	if err := pc.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer pc.Disconnect()
+	awaitConnected(t, pc, 5*time.Second)
+
+	res := fakeResolver{peers: map[string]manager.PeerConnection{"silent": pc}}
+	s := NewSender(res)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err := s.Send(ctx, "silent", validCCR())
+	elapsed := time.Since(start)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Send err = %v; want context.DeadlineExceeded", err)
+	}
+	// Sanity: aborted within ~250ms (allow generous slack).
+	if elapsed > 2*time.Second {
+		t.Errorf("Send took %s; expected ~250ms", elapsed)
+	}
+}

--- a/internal/diameter/messaging/types.go
+++ b/internal/diameter/messaging/types.go
@@ -1,0 +1,195 @@
+package messaging
+
+import (
+	"errors"
+	"time"
+
+	"github.com/fiorix/go-diameter/v4/diam"
+)
+
+// CC-Request-Type values defined by RFC 4006 §8.3. Re-exposed at
+// the package root so callers can build a CCR without importing
+// the diam library directly.
+const (
+	// CCRTypeInitial is CC-Request-Type = 1 (INITIAL_REQUEST).
+	CCRTypeInitial uint32 = 1
+	// CCRTypeUpdate is CC-Request-Type = 2 (UPDATE_REQUEST).
+	CCRTypeUpdate uint32 = 2
+	// CCRTypeTerminate is CC-Request-Type = 3 (TERMINATION_REQUEST).
+	CCRTypeTerminate uint32 = 3
+	// CCRTypeEvent is CC-Request-Type = 4 (EVENT_REQUEST).
+	CCRTypeEvent uint32 = 4
+)
+
+// CCR is the Go-native shape of a Credit-Control-Request the
+// caller hands to the Sender. Required fields (per RFC 4006 §3.1)
+// are surfaced as their own properties so the encoder can validate
+// them; ExtraAVPs is the catch-all for anything else (Subscription-
+// Id, User-Equipment-Info, Multiple-Services-Credit-Control,
+// Service-Information sub-tree, vendor AVPs, …).
+//
+// The Sender populates Session-Id and the Origin-Host /
+// Origin-Realm from the peer's PeerConfig if the caller leaves
+// them empty — both are peer-scoped per ARCHITECTURE §4 and
+// pre-filling them from the connection is the natural default.
+//
+// CCR is internal — it is NOT a contract serialised on the wire.
+// The wire form is the *diam.Message produced by BuildCCRMessage.
+// Field renames here do not break consumers of the wire protocol.
+type CCR struct {
+	// SessionID is the Session-Id AVP (RFC 6733 §8.8). The Sender
+	// generates one when empty; setting it lets the caller chain
+	// related CCRs (Initial → Update → Terminate) under the same
+	// session.
+	SessionID string
+
+	// OriginHost / OriginRealm are the local peer's identity. The
+	// Sender pre-fills these from PeerConfig when empty.
+	OriginHost  string
+	OriginRealm string
+
+	// DestinationRealm is mandatory per RFC 4006. If empty, the
+	// Sender uses PeerConfig.OriginRealm as a sensible default
+	// (typical OCS deployments live in the same realm as the
+	// testbench).
+	DestinationRealm string
+	// DestinationHost is optional (proxy/agent routing).
+	DestinationHost string
+
+	// AuthApplicationID is the Auth-Application-Id AVP. Defaults
+	// to 4 (Credit-Control) when zero.
+	AuthApplicationID uint32
+
+	// ServiceContextID is the Service-Context-Id AVP. Required by
+	// RFC 4006; the Sender does not invent a default — leaving it
+	// empty produces a CCR that the OCS will reject with a 5xxx
+	// permanent failure.
+	ServiceContextID string
+
+	// CCRequestType is the CC-Request-Type AVP. One of
+	// CCRTypeInitial / CCRTypeUpdate / CCRTypeTerminate /
+	// CCRTypeEvent.
+	CCRequestType uint32
+	// CCRequestNumber is the CC-Request-Number AVP. Caller-managed
+	// so a session's numbering scheme stays consistent.
+	CCRequestNumber uint32
+
+	// EventTimestamp is the Event-Timestamp AVP. When zero, the
+	// Sender stamps it with the current time at encode time.
+	EventTimestamp time.Time
+
+	// ExtraAVPs is the slice of additional AVPs to inject into the
+	// CCR. The Sender appends these after the required AVPs are
+	// laid down. Order in this slice is preserved on the wire.
+	//
+	// Typical contents: Subscription-Id, User-Equipment-Info,
+	// Multiple-Services-Indicator, Multiple-Services-Credit-
+	// Control (one or more), Service-Information sub-tree,
+	// vendor-specific AVPs.
+	ExtraAVPs []*diam.AVP
+}
+
+// MSCCBlock is the structured view of one Multiple-Services-Credit-
+// Control AVP from a CCA. The Sender returns these alongside the
+// raw AVP so the engine can read individual fields without
+// re-parsing.
+type MSCCBlock struct {
+	// ServiceIdentifier is the Service-Identifier AVP from this
+	// MSCC block, when present. Zero indicates absent (RFC 4006
+	// reserves 0 only for default; absent is more common).
+	ServiceIdentifier uint32
+	// RatingGroup is the Rating-Group AVP, when present.
+	RatingGroup uint32
+	// ResultCode is the per-MSCC Result-Code AVP. Zero indicates
+	// absent.
+	ResultCode uint32
+	// GrantedTime is the granted CC-Time, in seconds, when the
+	// Granted-Service-Unit AVP carries a CC-Time sub-AVP. Zero
+	// indicates "not granted" (the AVP may still grant
+	// volume/money via the other sub-fields, not surfaced here).
+	GrantedTime uint32
+	// GrantedTotalOctets is the granted CC-Total-Octets, in
+	// octets.
+	GrantedTotalOctets uint64
+	// ValidityTime is the Validity-Time AVP under this MSCC, in
+	// seconds. Zero indicates absent.
+	ValidityTime uint32
+	// FUIAction is the Final-Unit-Action sub-AVP under this
+	// MSCC's Final-Unit-Indication, when present. -1 indicates
+	// "no FUI present".
+	FUIAction int32
+	// Raw is the original *diam.AVP. Engine layers that need
+	// access to fields not surfaced above can read them from here.
+	Raw *diam.AVP
+}
+
+// FinalUnitAction values per RFC 4006 §8.34 Final-Unit-Action.
+const (
+	// FUIActionTerminate signals the session must be terminated
+	// (CCR-T) — task 5 owns the auto-emit.
+	FUIActionTerminate int32 = 0
+	// FUIActionRedirect signals the user is redirected.
+	FUIActionRedirect int32 = 1
+	// FUIActionRestrictAccess signals access is restricted to a
+	// list of filters.
+	FUIActionRestrictAccess int32 = 2
+)
+
+// CCA is the Go-native shape of a Credit-Control-Answer returned
+// by the Sender. Mirrors CCR's surface for the headline fields
+// plus the response-specific MSCC blocks and the top-level
+// Validity-Time / Final-Unit-Indication.
+type CCA struct {
+	// SessionID echoes the CCR's Session-Id so callers can
+	// correlate without holding state outside the CCR.
+	SessionID string
+
+	// OriginHost / OriginRealm identify the responding peer (the
+	// OCS).
+	OriginHost  string
+	OriginRealm string
+
+	// AuthApplicationID echoes the CCR's value.
+	AuthApplicationID uint32
+
+	// ResultCode is the top-level Result-Code AVP. RFC 6733 §7.1
+	// defines the ranges; task 5's protocol-behaviour layer
+	// branches on the 5xxx range for permanent failure.
+	ResultCode uint32
+
+	// CCRequestType / CCRequestNumber echo the CCR's values.
+	CCRequestType   uint32
+	CCRequestNumber uint32
+
+	// ValidityTime is the top-level Validity-Time AVP, in
+	// seconds, when present at the message level. Zero indicates
+	// absent. (Per-MSCC Validity-Time lives on each MSCCBlock.)
+	ValidityTime uint32
+
+	// FUIAction is the message-level Final-Unit-Indication's
+	// Final-Unit-Action sub-AVP, when present. -1 indicates
+	// "no top-level FUI present". Per-MSCC FUI lives on
+	// MSCCBlock.FUIAction.
+	FUIAction int32
+
+	// MSCC is the ordered list of decoded
+	// Multiple-Services-Credit-Control AVPs in the CCA.
+	MSCC []MSCCBlock
+
+	// Raw is the *diam.Message returned by go-diameter, exposed
+	// so callers that need a field not surfaced above can dig it
+	// out via FindAVP / FindAVPs.
+	Raw *diam.Message
+}
+
+// Sentinel errors raised by this package. Callers branch via
+// errors.Is.
+var (
+	// ErrInvalidCCR is returned by the encoder when a required
+	// field on the CCR is zero (Session-Id derivation aside).
+	ErrInvalidCCR = errors.New("messaging: invalid CCR")
+	// ErrCorrelatorClosed is returned by Send when the correlator
+	// channel was closed before a response was received — signals
+	// the connection dropped mid-request.
+	ErrCorrelatorClosed = errors.New("messaging: response channel closed (peer dropped)")
+)

--- a/internal/diameter/protocol/behaviour.go
+++ b/internal/diameter/protocol/behaviour.go
@@ -1,0 +1,407 @@
+package protocol
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/eddiecarpenter/ocs-testbench/internal/diameter/messaging"
+	"github.com/eddiecarpenter/ocs-testbench/internal/logging"
+)
+
+// DefaultReAuthMargin is the cushion applied when scheduling a
+// CCR-Update against a CCA's Validity-Time. The timer fires
+// `Validity-Time - DefaultReAuthMargin` seconds after the CCA
+// arrives so the re-auth lands before the grant actually expires.
+//
+// Five seconds matches the suggestion in the design plan and is a
+// reasonable trade-off between re-auth latency and clock skew. A
+// shorter margin risks the engine missing the validity window;
+// longer means re-auth fires more often than strictly necessary.
+const DefaultReAuthMargin = 5 * time.Second
+
+// minScheduleDelay is the floor applied when validity time minus
+// the re-auth margin would produce a non-positive duration. We
+// schedule the re-auth immediately rather than not at all so an
+// abnormally short Validity-Time doesn't silently disable
+// re-authorisation.
+const minScheduleDelay = 100 * time.Millisecond
+
+// resultCodePermanentFailureLow / High are the bounds of the
+// permanent-failure range per RFC 6733 §7.1.7.
+const (
+	resultCodePermanentFailureLow  uint32 = 5000
+	resultCodePermanentFailureHigh uint32 = 5999
+)
+
+// ErrSessionTerminated is returned by Send when the session
+// identified by req.SessionID was previously marked terminated
+// (FUI-TERMINATE seen, 5xxx seen). Callers branch on this via
+// errors.Is.
+var ErrSessionTerminated = errors.New("protocol: session terminated")
+
+// CCRUpdateBuilder builds the CCR the Behaviour issues to refresh
+// a grant approaching its Validity-Time expiry. The Behaviour
+// supplies the session id and the CC-Request-Number it expects
+// the next request to carry (one greater than the most recent
+// Send for that session); the builder fills in the rest of the
+// CCR (Service-Context-Id, MSCC, Subscription-Id, …).
+//
+// Production wiring supplies a closure that consults the engine's
+// per-session state. Tests supply a stub that asserts on the
+// session id.
+type CCRUpdateBuilder func(sessionID string, ccRequestNumber uint32) *messaging.CCR
+
+// CCRTerminateBuilder builds the CCR-Terminate the Behaviour
+// issues automatically when a CCA carries FUI = TERMINATE. Same
+// pattern as CCRUpdateBuilder; the Behaviour fills in the
+// CC-Request-Type as Terminate before sending.
+type CCRTerminateBuilder func(sessionID string, ccRequestNumber uint32) *messaging.CCR
+
+// Options configures the Behaviour. Every field is optional; the
+// zero value is acceptable (re-auth scheduling and CCR-T emission
+// will be no-ops without builders).
+type Options struct {
+	// ReAuthMargin overrides the default cushion applied to
+	// Validity-Time when scheduling re-auth. Zero means
+	// DefaultReAuthMargin.
+	ReAuthMargin time.Duration
+
+	// CCRUpdate is the builder the Behaviour invokes to construct
+	// the re-auth CCR-Update fired before a Validity-Time
+	// expires. Nil means re-auth is not scheduled.
+	CCRUpdate CCRUpdateBuilder
+
+	// CCRTerminate is the builder the Behaviour invokes to
+	// construct the auto CCR-Terminate fired when FUI = TERMINATE
+	// is observed. Nil means CCR-T is not emitted (the session
+	// is still marked terminated).
+	CCRTerminate CCRTerminateBuilder
+
+	// PeerNameOf returns the peer name to send out-of-band CCRs
+	// against, given a session id. The Behaviour records the peer
+	// for every Send it observes, so this hook is only consulted
+	// when a session is being terminated/re-authed before it has
+	// been sent on; in normal operation the recorded peer is
+	// used.
+	PeerNameOf func(sessionID string) string
+
+	// Now is the clock the Behaviour uses for re-auth scheduling.
+	// Zero means time.Now.
+	Now func() time.Time
+
+	// AfterFunc is the seam the Behaviour uses to schedule timers.
+	// Zero means time.AfterFunc. Tests substitute a synchronous
+	// scheduler so re-auth fires immediately.
+	AfterFunc func(d time.Duration, fn func()) Timer
+}
+
+// Timer is the small surface of time.Timer the Behaviour uses.
+// Defined as its own interface so tests can substitute a fake
+// timer that fires synchronously.
+type Timer interface {
+	// Stop cancels the timer. Returns true if the call stopped
+	// the timer, false if the timer has already expired or been
+	// stopped.
+	Stop() bool
+}
+
+// realTimer wraps *time.Timer to satisfy the Timer interface.
+type realTimer struct{ t *time.Timer }
+
+func (r *realTimer) Stop() bool { return r.t.Stop() }
+
+// realAfterFunc is the production AfterFunc — defers to
+// time.AfterFunc.
+func realAfterFunc(d time.Duration, fn func()) Timer {
+	return &realTimer{t: time.AfterFunc(d, fn)}
+}
+
+// Behaviour is the protocol-mandated CCA observer. It wraps a
+// messaging.Sender and itself implements messaging.Sender so
+// callers can swap it in transparently.
+//
+// Construct via New. Lifecycle:
+//
+//   - Send delegates to the wrapped Sender, then observes the
+//     returned CCA: marks the session terminated on
+//     FUI-TERMINATE or 5xxx, schedules / refreshes re-auth on
+//     Validity-Time, and tracks the most recent CC-Request-Number
+//     so the builder hook can produce the next CCR.
+//   - SessionTerminated reports whether a session has been
+//     terminated by the Behaviour (test / introspection hook).
+//   - Stop cancels every outstanding re-auth timer and clears the
+//     session map. Idempotent.
+//
+// Concurrency: every public method is goroutine-safe.
+type Behaviour struct {
+	inner messaging.Sender
+	opt   Options
+
+	mu       sync.Mutex
+	sessions map[string]*sessionState
+	stopped  bool
+}
+
+// sessionState is the Behaviour's per-session bookkeeping.
+type sessionState struct {
+	peerName        string
+	ccRequestNumber uint32
+	terminated      bool
+	timer           Timer
+}
+
+// New constructs a Behaviour decorating inner. Panics on a nil
+// inner — wiring a Behaviour against a nil Sender is a
+// programming error.
+func New(inner messaging.Sender, opts Options) *Behaviour {
+	if inner == nil {
+		panic("protocol.New: inner sender must not be nil")
+	}
+	if opts.ReAuthMargin <= 0 {
+		opts.ReAuthMargin = DefaultReAuthMargin
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	if opts.AfterFunc == nil {
+		opts.AfterFunc = realAfterFunc
+	}
+	return &Behaviour{
+		inner:    inner,
+		opt:      opts,
+		sessions: map[string]*sessionState{},
+	}
+}
+
+// Send is the messaging.Sender implementation. It delegates to
+// the wrapped sender, observes the response, and applies
+// protocol-mandated actions before returning the CCA verbatim.
+func (b *Behaviour) Send(ctx context.Context, peerName string, req *messaging.CCR) (*messaging.CCA, error) {
+	if req != nil && req.SessionID != "" {
+		b.mu.Lock()
+		state := b.sessions[req.SessionID]
+		terminated := state != nil && state.terminated
+		b.mu.Unlock()
+		if terminated {
+			return nil, fmt.Errorf("%w: session %q", ErrSessionTerminated, req.SessionID)
+		}
+	}
+
+	cca, err := b.inner.Send(ctx, peerName, req)
+	if err != nil {
+		return nil, err
+	}
+
+	b.observeCCA(peerName, req, cca)
+	return cca, nil
+}
+
+// observeCCA inspects the CCA and updates session state. Called
+// after every successful Send.
+//
+// Order of operations matters: 5xxx and FUI-TERMINATE are checked
+// before Validity-Time scheduling, because a terminated session
+// does not need a re-auth timer.
+func (b *Behaviour) observeCCA(peerName string, req *messaging.CCR, cca *messaging.CCA) {
+	if cca == nil {
+		return
+	}
+	sessionID := cca.SessionID
+	if sessionID == "" && req != nil {
+		sessionID = req.SessionID
+	}
+	if sessionID == "" {
+		return
+	}
+
+	b.mu.Lock()
+	state := b.sessions[sessionID]
+	if state == nil {
+		state = &sessionState{peerName: peerName}
+		b.sessions[sessionID] = state
+	}
+	state.peerName = peerName
+	if req != nil && req.CCRequestNumber > state.ccRequestNumber {
+		state.ccRequestNumber = req.CCRequestNumber
+	}
+
+	// Permanent failure (5xxx) — terminate the session.
+	if isPermanentFailure(cca.ResultCode) {
+		state.terminated = true
+		b.cancelTimerLocked(state)
+		b.mu.Unlock()
+		logging.Info(
+			"protocol: session terminated by 5xxx Result-Code",
+			"session_id", sessionID,
+			"result_code", cca.ResultCode,
+		)
+		return
+	}
+
+	// FUI = TERMINATE — terminate the session AND fire CCR-T.
+	if cca.FUIAction == messaging.FUIActionTerminate {
+		state.terminated = true
+		b.cancelTimerLocked(state)
+		nextRN := state.ccRequestNumber + 1
+		state.ccRequestNumber = nextRN
+		builder := b.opt.CCRTerminate
+		b.mu.Unlock()
+		logging.Info(
+			"protocol: FUI=TERMINATE → emitting CCR-Terminate",
+			"session_id", sessionID,
+			"cc_request_number", nextRN,
+		)
+		if builder != nil {
+			b.emitTerminate(peerName, sessionID, nextRN, builder)
+		}
+		return
+	}
+
+	// Validity-Time present — schedule (or refresh) re-auth.
+	if cca.ValidityTime > 0 {
+		b.cancelTimerLocked(state)
+		delay := time.Duration(cca.ValidityTime)*time.Second - b.opt.ReAuthMargin
+		if delay < minScheduleDelay {
+			delay = minScheduleDelay
+		}
+		afterFunc := b.opt.AfterFunc
+		state.timer = afterFunc(delay, func() {
+			b.fireReAuth(sessionID)
+		})
+		b.mu.Unlock()
+		logging.Info(
+			"protocol: scheduled re-auth",
+			"session_id", sessionID,
+			"validity_time_seconds", cca.ValidityTime,
+			"reauth_in", delay.String(),
+		)
+		return
+	}
+
+	b.mu.Unlock()
+}
+
+// fireReAuth is the timer callback. Issues a CCR-Update via the
+// inner Sender if the session is still active.
+func (b *Behaviour) fireReAuth(sessionID string) {
+	b.mu.Lock()
+	state := b.sessions[sessionID]
+	if state == nil || state.terminated || b.stopped {
+		b.mu.Unlock()
+		return
+	}
+	peerName := state.peerName
+	nextRN := state.ccRequestNumber + 1
+	state.ccRequestNumber = nextRN
+	state.timer = nil
+	builder := b.opt.CCRUpdate
+	b.mu.Unlock()
+
+	if builder == nil {
+		return
+	}
+	logging.Info(
+		"protocol: firing scheduled re-auth",
+		"session_id", sessionID,
+		"cc_request_number", nextRN,
+	)
+	req := builder(sessionID, nextRN)
+	if req == nil {
+		return
+	}
+	req.SessionID = sessionID
+	req.CCRequestType = messaging.CCRTypeUpdate
+	req.CCRequestNumber = nextRN
+
+	// Re-auth happens with a fresh background context; the
+	// engine's caller context cannot be the bound context here
+	// because the re-auth is asynchronous.
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if _, err := b.Send(ctx, peerName, req); err != nil {
+			logging.Warn(
+				"protocol: scheduled re-auth failed",
+				"session_id", sessionID,
+				"peer", peerName,
+				"error", err.Error(),
+			)
+		}
+	}()
+}
+
+// emitTerminate sends an automatic CCR-Terminate for a session
+// that just observed FUI=TERMINATE. Runs in a fresh goroutine so
+// the original Send returns to the caller immediately.
+func (b *Behaviour) emitTerminate(peerName, sessionID string, nextRN uint32, builder CCRTerminateBuilder) {
+	go func() {
+		req := builder(sessionID, nextRN)
+		if req == nil {
+			return
+		}
+		req.SessionID = sessionID
+		req.CCRequestType = messaging.CCRTypeTerminate
+		req.CCRequestNumber = nextRN
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		// Bypass the Behaviour's own SessionTerminated guard by
+		// going through the inner sender directly — the session
+		// IS terminated, but we still need to put the
+		// CCR-Terminate on the wire so the OCS knows to release
+		// resources.
+		if _, err := b.inner.Send(ctx, peerName, req); err != nil {
+			logging.Warn(
+				"protocol: auto CCR-Terminate failed",
+				"session_id", sessionID,
+				"peer", peerName,
+				"error", err.Error(),
+			)
+		}
+	}()
+}
+
+// cancelTimerLocked stops a session's pending re-auth timer.
+// Caller must hold b.mu.
+func (b *Behaviour) cancelTimerLocked(s *sessionState) {
+	if s.timer != nil {
+		s.timer.Stop()
+		s.timer = nil
+	}
+}
+
+// SessionTerminated reports whether a session has been marked
+// terminated by the Behaviour. Convenience for tests and
+// introspection.
+func (b *Behaviour) SessionTerminated(sessionID string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	s := b.sessions[sessionID]
+	return s != nil && s.terminated
+}
+
+// Stop cancels every outstanding re-auth timer and clears the
+// session map. Subsequent calls to Send return
+// ErrSessionTerminated for any session that was tracked. Stop is
+// idempotent.
+func (b *Behaviour) Stop() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.stopped {
+		return
+	}
+	b.stopped = true
+	for id, s := range b.sessions {
+		b.cancelTimerLocked(s)
+		s.terminated = true
+		_ = id
+	}
+}
+
+// isPermanentFailure reports whether code is in the 5xxx
+// permanent-failure range.
+func isPermanentFailure(code uint32) bool {
+	return code >= resultCodePermanentFailureLow && code <= resultCodePermanentFailureHigh
+}

--- a/internal/diameter/protocol/behaviour_test.go
+++ b/internal/diameter/protocol/behaviour_test.go
@@ -1,0 +1,597 @@
+package protocol
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eddiecarpenter/ocs-testbench/internal/diameter/messaging"
+)
+
+// fakeSender is the test stand-in for messaging.Sender. Records
+// every Send call and returns a canned response per session id /
+// CC-Request-Type.
+type fakeSender struct {
+	mu    sync.Mutex
+	calls []sendCall
+	resp  func(req *messaging.CCR) (*messaging.CCA, error)
+}
+
+type sendCall struct {
+	peer string
+	req  *messaging.CCR
+}
+
+func (f *fakeSender) Send(_ context.Context, peer string, req *messaging.CCR) (*messaging.CCA, error) {
+	f.mu.Lock()
+	f.calls = append(f.calls, sendCall{peer: peer, req: copyCCR(req)})
+	resp := f.resp
+	f.mu.Unlock()
+	if resp == nil {
+		return &messaging.CCA{SessionID: req.SessionID, ResultCode: 2001, FUIAction: -1}, nil
+	}
+	return resp(req)
+}
+
+// copyCCR returns a deep-enough copy of req for assertions —
+// captures session id, CC-Request-Type / Number.
+func copyCCR(req *messaging.CCR) *messaging.CCR {
+	if req == nil {
+		return nil
+	}
+	c := *req
+	return &c
+}
+
+// callCount returns the number of recorded Send calls.
+func (f *fakeSender) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+// callsFor returns the recorded calls whose req.SessionID matches
+// sid.
+func (f *fakeSender) callsFor(sid string) []sendCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]sendCall, 0)
+	for _, c := range f.calls {
+		if c.req != nil && c.req.SessionID == sid {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// fakeTimer is a Timer that fires synchronously when the test
+// drives it, or never if the test doesn't.
+type fakeTimer struct {
+	fn      func()
+	stopped atomic.Bool
+}
+
+func (t *fakeTimer) Stop() bool {
+	already := t.stopped.Swap(true)
+	return !already
+}
+
+// fire invokes the timer's callback if it has not been stopped.
+func (t *fakeTimer) fire() {
+	if t.stopped.Load() {
+		return
+	}
+	t.fn()
+}
+
+// fakeScheduler captures every AfterFunc call so the test can
+// inspect / fire timers deterministically.
+type fakeScheduler struct {
+	mu     sync.Mutex
+	timers []*fakeTimer
+}
+
+func (s *fakeScheduler) AfterFunc() func(d time.Duration, fn func()) Timer {
+	return func(_ time.Duration, fn func()) Timer {
+		t := &fakeTimer{fn: fn}
+		s.mu.Lock()
+		s.timers = append(s.timers, t)
+		s.mu.Unlock()
+		return t
+	}
+}
+
+// last returns the most recently scheduled fakeTimer.
+func (s *fakeScheduler) last() *fakeTimer {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.timers) == 0 {
+		return nil
+	}
+	return s.timers[len(s.timers)-1]
+}
+
+// count returns how many timers were scheduled.
+func (s *fakeScheduler) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.timers)
+}
+
+// validCCR returns a minimal CCR with a fixed Session-Id and
+// Initial CC-Request-Type. Tests adjust as needed.
+func validCCR() *messaging.CCR {
+	return &messaging.CCR{
+		SessionID:        "sess-1",
+		ServiceContextID: "32251@3gpp.org",
+		DestinationRealm: "test.local",
+		CCRequestType:    messaging.CCRTypeInitial,
+		CCRequestNumber:  0,
+	}
+}
+
+// Test 1 (AC-12) — FUI=TERMINATE marks the session terminated and
+// fires CCR-Terminate exactly once.
+func TestBehaviour_FUITerminateEmitsCCRT(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeSender{
+		resp: func(req *messaging.CCR) (*messaging.CCA, error) {
+			// On the original CCR-Initial, return CCA with
+			// FUI=TERMINATE. On the CCR-Terminate, return a
+			// 2001 CCA.
+			if req.CCRequestType == messaging.CCRTypeInitial {
+				return &messaging.CCA{
+					SessionID:  req.SessionID,
+					ResultCode: 2001,
+					FUIAction:  messaging.FUIActionTerminate,
+				}, nil
+			}
+			return &messaging.CCA{
+				SessionID:  req.SessionID,
+				ResultCode: 2001,
+				FUIAction:  -1,
+			}, nil
+		},
+	}
+
+	var ccrtBuilds atomic.Int32
+	b := New(inner, Options{
+		CCRTerminate: func(sessionID string, ccRequestNumber uint32) *messaging.CCR {
+			ccrtBuilds.Add(1)
+			if sessionID != "sess-1" {
+				t.Errorf("CCRTerminate sessionID = %q; want sess-1", sessionID)
+			}
+			return &messaging.CCR{
+				SessionID:        sessionID,
+				DestinationRealm: "test.local",
+				ServiceContextID: "32251@3gpp.org",
+				CCRequestNumber:  ccRequestNumber,
+			}
+		},
+	})
+	defer b.Stop()
+
+	cca, err := b.Send(context.Background(), "p1", validCCR())
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if cca.FUIAction != messaging.FUIActionTerminate {
+		t.Errorf("CCA FUIAction = %d; want TERMINATE", cca.FUIAction)
+	}
+
+	// The CCR-T is sent in a goroutine — wait briefly.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if ccrtBuilds.Load() == 1 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if ccrtBuilds.Load() != 1 {
+		t.Errorf("CCR-Terminate builder calls = %d; want 1", ccrtBuilds.Load())
+	}
+
+	// Session should be marked terminated.
+	if !b.SessionTerminated("sess-1") {
+		t.Errorf("SessionTerminated(sess-1) = false; want true")
+	}
+
+	// A subsequent Send should fail with ErrSessionTerminated.
+	_, err = b.Send(context.Background(), "p1", validCCR())
+	if !errors.Is(err, ErrSessionTerminated) {
+		t.Errorf("Send after terminate err = %v; want ErrSessionTerminated", err)
+	}
+}
+
+// Test 2 (AC-12 — no builder) — FUI=TERMINATE without a builder
+// still marks the session terminated; no CCR-T is fired.
+func TestBehaviour_FUITerminateWithoutBuilder(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeSender{
+		resp: func(req *messaging.CCR) (*messaging.CCA, error) {
+			return &messaging.CCA{
+				SessionID:  req.SessionID,
+				ResultCode: 2001,
+				FUIAction:  messaging.FUIActionTerminate,
+			}, nil
+		},
+	}
+	b := New(inner, Options{})
+	defer b.Stop()
+
+	if _, err := b.Send(context.Background(), "p1", validCCR()); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	// Give any leaked goroutine time to fire — we expect none.
+	time.Sleep(50 * time.Millisecond)
+
+	if !b.SessionTerminated("sess-1") {
+		t.Errorf("SessionTerminated = false; want true")
+	}
+	// Only the original Send should have hit the inner sender.
+	if got := inner.callCount(); got != 1 {
+		t.Errorf("inner Send calls = %d; want 1", got)
+	}
+}
+
+// Test 3 (AC-13) — 5xxx Result-Code marks the session terminated;
+// no CCR-T fires; subsequent Send returns ErrSessionTerminated.
+func TestBehaviour_PermanentFailureTerminates(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeSender{
+		resp: func(req *messaging.CCR) (*messaging.CCA, error) {
+			return &messaging.CCA{
+				SessionID:  req.SessionID,
+				ResultCode: 5012, // DIAMETER_UNABLE_TO_COMPLY
+				FUIAction:  -1,
+			}, nil
+		},
+	}
+	var ccrtBuilds atomic.Int32
+	b := New(inner, Options{
+		CCRTerminate: func(string, uint32) *messaging.CCR {
+			ccrtBuilds.Add(1)
+			return nil
+		},
+	})
+	defer b.Stop()
+
+	if _, err := b.Send(context.Background(), "p1", validCCR()); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if !b.SessionTerminated("sess-1") {
+		t.Errorf("SessionTerminated = false; want true")
+	}
+	// 5xxx must NOT trigger CCR-T — that's only FUI's path.
+	time.Sleep(50 * time.Millisecond)
+	if got := ccrtBuilds.Load(); got != 0 {
+		t.Errorf("CCR-Terminate builder calls = %d; want 0 (5xxx is not FUI)", got)
+	}
+
+	// Subsequent Send should fail.
+	_, err := b.Send(context.Background(), "p1", validCCR())
+	if !errors.Is(err, ErrSessionTerminated) {
+		t.Errorf("Send after 5xxx err = %v; want ErrSessionTerminated", err)
+	}
+}
+
+// Test 4 (AC-13) — 4010 (Credit-Limit-Reached, transient) is NOT
+// in the 5xxx range and must not terminate the session.
+func TestBehaviour_TransientFailureDoesNotTerminate(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeSender{
+		resp: func(req *messaging.CCR) (*messaging.CCA, error) {
+			return &messaging.CCA{
+				SessionID:  req.SessionID,
+				ResultCode: 4010, // CREDIT_LIMIT_REACHED — transient
+				FUIAction:  -1,
+			}, nil
+		},
+	}
+	b := New(inner, Options{})
+	defer b.Stop()
+
+	if _, err := b.Send(context.Background(), "p1", validCCR()); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if b.SessionTerminated("sess-1") {
+		t.Errorf("SessionTerminated for 4010 = true; want false")
+	}
+}
+
+// Test 5 (AC-11) — Validity-Time schedules a re-auth timer and
+// firing it issues a CCR-Update via the builder.
+func TestBehaviour_ValidityTimeSchedulesReAuth(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeSender{
+		resp: func(req *messaging.CCR) (*messaging.CCA, error) {
+			// Initial CCR returns Validity-Time = 30s.
+			// CCR-Update returns Validity-Time = 0 (no further
+			// re-auth).
+			validity := uint32(0)
+			if req.CCRequestType == messaging.CCRTypeInitial {
+				validity = 30
+			}
+			return &messaging.CCA{
+				SessionID:    req.SessionID,
+				ResultCode:   2001,
+				FUIAction:    -1,
+				ValidityTime: validity,
+			}, nil
+		},
+	}
+
+	sched := &fakeScheduler{}
+	var reauthBuilds atomic.Int32
+	b := New(inner, Options{
+		AfterFunc: sched.AfterFunc(),
+		CCRUpdate: func(sessionID string, n uint32) *messaging.CCR {
+			reauthBuilds.Add(1)
+			if sessionID != "sess-1" {
+				t.Errorf("CCRUpdate sessionID = %q; want sess-1", sessionID)
+			}
+			return &messaging.CCR{
+				SessionID:        sessionID,
+				DestinationRealm: "test.local",
+				ServiceContextID: "32251@3gpp.org",
+				CCRequestNumber:  n,
+			}
+		},
+	})
+	defer b.Stop()
+
+	if _, err := b.Send(context.Background(), "p1", validCCR()); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if got := sched.count(); got != 1 {
+		t.Fatalf("scheduled timers = %d; want 1", got)
+	}
+
+	// Fire the timer — should produce a CCR-Update.
+	sched.last().fire()
+
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		if reauthBuilds.Load() == 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if reauthBuilds.Load() != 1 {
+		t.Errorf("CCRUpdate builder calls = %d; want 1", reauthBuilds.Load())
+	}
+
+	// The re-auth Send must have hit the inner sender.
+	deadline = time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		if inner.callCount() == 2 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := inner.callCount(); got != 2 {
+		t.Errorf("inner Send calls after reauth = %d; want 2", got)
+	}
+	// And the second call should have been CCR-Update.
+	calls := inner.callsFor("sess-1")
+	if len(calls) < 2 {
+		t.Fatalf("calls for sess-1 = %d; want at least 2", len(calls))
+	}
+	second := calls[1]
+	if second.req.CCRequestType != messaging.CCRTypeUpdate {
+		t.Errorf("second call CCRequestType = %d; want Update (%d)",
+			second.req.CCRequestType, messaging.CCRTypeUpdate)
+	}
+}
+
+// Test 6 (AC-11) — a later CCA carrying a fresh Validity-Time
+// cancels the prior timer and reschedules.
+func TestBehaviour_ValidityTimeRefreshCancelsPrior(t *testing.T) {
+	t.Parallel()
+
+	respValidity := uint32(30)
+	inner := &fakeSender{
+		resp: func(req *messaging.CCR) (*messaging.CCA, error) {
+			return &messaging.CCA{
+				SessionID:    req.SessionID,
+				ResultCode:   2001,
+				FUIAction:    -1,
+				ValidityTime: respValidity,
+			}, nil
+		},
+	}
+	sched := &fakeScheduler{}
+	b := New(inner, Options{
+		AfterFunc: sched.AfterFunc(),
+		CCRUpdate: func(string, uint32) *messaging.CCR { return validCCR() },
+	})
+	defer b.Stop()
+
+	// First Send schedules timer 1.
+	if _, err := b.Send(context.Background(), "p1", validCCR()); err != nil {
+		t.Fatalf("first Send: %v", err)
+	}
+	t1 := sched.last()
+	if t1 == nil {
+		t.Fatalf("no timer scheduled after first Send")
+	}
+
+	// Second Send (e.g. an Update with a fresh Validity-Time)
+	// schedules timer 2 and cancels timer 1.
+	r2 := validCCR()
+	r2.CCRequestType = messaging.CCRTypeUpdate
+	r2.CCRequestNumber = 1
+	if _, err := b.Send(context.Background(), "p1", r2); err != nil {
+		t.Fatalf("second Send: %v", err)
+	}
+	if got := sched.count(); got != 2 {
+		t.Fatalf("scheduled timers = %d; want 2", got)
+	}
+	if !t1.stopped.Load() {
+		t.Errorf("first timer not stopped after refresh")
+	}
+}
+
+// Test 7 — Validity-Time is ignored when the session was just
+// terminated by the same CCA's FUI=TERMINATE.
+func TestBehaviour_ValidityTimeIgnoredOnTerminatedCCA(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeSender{
+		resp: func(req *messaging.CCR) (*messaging.CCA, error) {
+			return &messaging.CCA{
+				SessionID:    req.SessionID,
+				ResultCode:   2001,
+				FUIAction:    messaging.FUIActionTerminate,
+				ValidityTime: 30, // would normally schedule
+			}, nil
+		},
+	}
+	sched := &fakeScheduler{}
+	b := New(inner, Options{
+		AfterFunc: sched.AfterFunc(),
+		CCRUpdate: func(string, uint32) *messaging.CCR { return validCCR() },
+	})
+	defer b.Stop()
+
+	if _, err := b.Send(context.Background(), "p1", validCCR()); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if got := sched.count(); got != 0 {
+		t.Errorf("scheduled timers on terminated CCA = %d; want 0", got)
+	}
+}
+
+// Test 8 — Stop cancels every outstanding timer and marks all
+// tracked sessions terminated.
+func TestBehaviour_StopCancelsTimers(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeSender{
+		resp: func(req *messaging.CCR) (*messaging.CCA, error) {
+			return &messaging.CCA{
+				SessionID:    req.SessionID,
+				ResultCode:   2001,
+				FUIAction:    -1,
+				ValidityTime: 30,
+			}, nil
+		},
+	}
+	sched := &fakeScheduler{}
+	b := New(inner, Options{
+		AfterFunc: sched.AfterFunc(),
+		CCRUpdate: func(string, uint32) *messaging.CCR { return validCCR() },
+	})
+
+	if _, err := b.Send(context.Background(), "p1", validCCR()); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if sched.count() != 1 {
+		t.Fatalf("scheduled timers = %d; want 1", sched.count())
+	}
+	b.Stop()
+	if !sched.last().stopped.Load() {
+		t.Errorf("timer not stopped by Stop()")
+	}
+	if !b.SessionTerminated("sess-1") {
+		t.Errorf("SessionTerminated after Stop = false; want true")
+	}
+	// Stop is idempotent.
+	b.Stop()
+}
+
+// Test 9 — inner sender error propagates without observing the
+// (nil) CCA.
+func TestBehaviour_InnerErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	want := errors.New("inner failed")
+	inner := &fakeSender{
+		resp: func(_ *messaging.CCR) (*messaging.CCA, error) {
+			return nil, want
+		},
+	}
+	b := New(inner, Options{})
+	defer b.Stop()
+	_, err := b.Send(context.Background(), "p1", validCCR())
+	if !errors.Is(err, want) {
+		t.Errorf("Send err = %v; want %v", err, want)
+	}
+	// Session must NOT be marked terminated by an inner error.
+	if b.SessionTerminated("sess-1") {
+		t.Errorf("SessionTerminated on inner error = true; want false")
+	}
+}
+
+// Test 10 — nil inner Sender panics.
+func TestNew_NilInnerPanics(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic on nil inner")
+		}
+	}()
+	New(nil, Options{})
+}
+
+// Test 11 — isPermanentFailure boundary cases.
+func TestIsPermanentFailure(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		code uint32
+		want bool
+	}{
+		{0, false},
+		{2001, false},
+		{4010, false}, // transient
+		{4999, false},
+		{5000, true},
+		{5012, true},
+		{5999, true},
+		{6000, false},
+	}
+	for _, tc := range cases {
+		if got := isPermanentFailure(tc.code); got != tc.want {
+			t.Errorf("isPermanentFailure(%d) = %v; want %v", tc.code, got, tc.want)
+		}
+	}
+}
+
+// Test 12 — short Validity-Time falls back to minScheduleDelay
+// rather than producing a non-positive timer.
+func TestBehaviour_ShortValidityTimeUsesFloor(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeSender{
+		resp: func(req *messaging.CCR) (*messaging.CCA, error) {
+			return &messaging.CCA{
+				SessionID:    req.SessionID,
+				ResultCode:   2001,
+				FUIAction:    -1,
+				ValidityTime: 1, // less than the 5s margin
+			}, nil
+		},
+	}
+	sched := &fakeScheduler{}
+	b := New(inner, Options{
+		AfterFunc:    sched.AfterFunc(),
+		CCRUpdate:    func(string, uint32) *messaging.CCR { return validCCR() },
+		ReAuthMargin: 5 * time.Second,
+	})
+	defer b.Stop()
+
+	if _, err := b.Send(context.Background(), "p1", validCCR()); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if sched.count() != 1 {
+		t.Errorf("scheduled timers = %d; want 1 (floor must apply)", sched.count())
+	}
+}

--- a/internal/diameter/protocol/doc.go
+++ b/internal/diameter/protocol/doc.go
@@ -1,0 +1,39 @@
+// Package protocol implements the protocol-mandated CCA behaviour
+// of the Diameter stack.
+//
+// docs/ARCHITECTURE.md §10.1 names three CCA-side behaviours that
+// are *protocol-mandated, not testing choices*:
+//
+//   - Final-Unit-Indication action TERMINATE → emit a CCR-Terminate
+//     for the same Session-Id automatically, without the engine
+//     having to ask.
+//   - Validity-Time → schedule a CCR-Update before the validity
+//     expires so the grant can be refreshed.
+//   - Top-level Result-Code in the 5xxx range → permanent failure;
+//     mark the session terminated so subsequent Send calls for
+//     that session fail fast with ErrSessionTerminated.
+//
+// This package implements those behaviours as a *decorator* over
+// the messaging.Sender interface. Wiring in
+// cmd/ocs-testbench/main.go produces a Behaviour-wrapped Sender
+// as the one the engine layer eventually consumes — the engine
+// sees the original CCA verbatim, and any out-of-band CCRs the
+// Behaviour issues happen behind the scenes.
+//
+// What this package explicitly does NOT handle:
+//
+//   - Per-MSCC 4010 / 4011 / 4012 result codes — those are the
+//     engine's per-Rating-Group state derivation per
+//     ARCHITECTURE §7.5. The Behaviour reads only the top-level
+//     Result-Code; per-MSCC codes flow through to the engine
+//     untouched.
+//   - Retry policy on transient failures — those are the engine's
+//     responsibility, surfaced as result-handler `retry` actions
+//     per ARCHITECTURE §10.2.
+//
+// Session state lives inside the Behaviour as a small
+// `sessions map[Session-Id]*sessionState`. It is internal — the
+// engine sees only the post-protocol effects (a session that is
+// terminated is terminated; a CCR-T already fired; a re-auth
+// timer is in flight).
+package protocol


### PR DESCRIPTION
## Why this PR exists

PR #140 squash-merged Tasks 1+2 of #17 (dictionary loader + per-peer connection lifecycle).

Tasks 3-5 (multi-peer manager, CCR/CCA messaging, protocol-mandated behaviour) were authored by the dev-session AFTER the merge but pushed onto the *pre-merge* branch tip, producing the conflicting PR #141. Cherry-picked cleanly here onto the post-merge main; PR #141 closed in favour of this one.

## Tasks landed

- **Task 3** (\`8cfc07e\`) — Multi-peer connection manager + auto-connect on startup. \`internal/diameter/manager/\` package.
- **Task 4** (\`2e7da3f\`) — CCR builder, CCA decoder, Sender interface with disconnected-peer guard. \`internal/diameter/messaging/\` package.
- **Task 5** (\`808bbcb\`) — Protocol-mandated CCA behaviour: FUI-TERMINATE, Validity-Time, 5xxx handling. \`internal/diameter/protocol/\` package.

## Verified locally

- \`gofmt -l\` clean (excluding \`.ai/\`)
- \`go vet ./...\` clean
- \`go mod tidy\` no drift
- \`go build ./...\` clean
- \`go test -race ./...\` all packages green

CI on main has Build and Test + Quality (Sonar). Both should pass without further intervention.

## Closes

Replaces PR #141.