### PR TITLE
chore: upgrade agentic framework to v2.6.0

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   pipeline:
-    uses: eddiecarpenter/gh-agentic/.github/workflows/agentic-pipeline.yml@v2.5.6
+    uses: eddiecarpenter/gh-agentic/.github/workflows/agentic-pipeline.yml@v2.6.0
     with:
       pr_number: ${{ inputs.pr_number || '' }}
       branch_name: ${{ inputs.branch_name || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    uses: eddiecarpenter/gh-agentic/.github/workflows/release.yml@v2.5.6
+    uses: eddiecarpenter/gh-agentic/.github/workflows/release.yml@v2.6.0
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Bumps gh-agentic framework from v2.5.5 / v2.5.6 → **v2.6.0** across all surfaces.
- Resolves the half-upgraded state where the repo variable (\`AGENTIC_FRAMEWORK_VERSION=v2.5.5\`) lagged the workflow refs (\`@v2.5.6\`).

## Files touched

- \`.github/workflows/agentic-pipeline.yml\` — reusable workflow ref bumped
- \`.github/workflows/release.yml\` — reusable workflow ref bumped
- \`.ai/\` submodule pointer → v2.6.0
- \`AGENTIC_FRAMEWORK_VERSION\` repo variable → v2.6.0 (set out-of-tree)

Custom workflows (\`build-and-test.yml\`, \`quality.yml\`) unchanged — they don't reference gh-agentic.

## Why now

We've been hitting recurring quirks on v2.5.x:

- Stage 3 → Stage 4 handoff race: branch created locally on the runner but never pushed; Stage 4 then bails with \"No branch found matching feature/N-*\".
- Post-flight \"rationale not found\" false negatives (GitHub indexing lag during the same workflow run).
- Dev-session re-firing on \`in-development\` AFTER a feature's PR has merged, producing a duplicate stale-branch PR (cf. PR #141 vs #140 today).
- Stage 5 Feature Complete failing on the \"branch already deleted\" 422.

v2.6.0 may address some of these — release notes worth reviewing. Even if not, the half-upgraded state is itself worth fixing.

## Verified

- \`go build ./...\` clean post-upgrade.
- Build and Test + Quality CI will run on this PR.

## Test plan

- [ ] CI green (Build and Test, Quality)
- [ ] Next agentic pipeline run uses v2.6.0 (visible in run logs as \`Uses: ...gh-agentic/...@refs/tags/v2.6.0\`)
- [ ] Smoke test: trigger any small feature design / dev session and confirm behaviour