### PR TITLE
chore: upgrade agentic framework to v2.6.4

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   pipeline:
-    uses: eddiecarpenter/gh-agentic/.github/workflows/agentic-pipeline.yml@v2.6.3
+    uses: eddiecarpenter/gh-agentic/.github/workflows/agentic-pipeline.yml@v2.6.4
     with:
       pr_number: ${{ inputs.pr_number || '' }}
       branch_name: ${{ inputs.branch_name || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    uses: eddiecarpenter/gh-agentic/.github/workflows/release.yml@v2.6.3
+    uses: eddiecarpenter/gh-agentic/.github/workflows/release.yml@v2.6.4
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Bump `.ai` submodule and workflow references from v2.6.3 to v2.6.4

## Test plan

- [ ] CI passes on this branch