### PR TITLE
chore: migrate agentic framework mount from .ai to .agents

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule ".ai"]
-	path = .ai
-	url = https://github.com/eddiecarpenter/gh-agentic.git
 [submodule ".agents"]
 	path = .agents
 	url = https://github.com/eddiecarpenter/gh-agentic.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,13 @@
 # AGENTS.md:OK
  
 # LOAD ORDER (ENFORCED)
-1. .ai/RULEBOOK.md
+1. .agents/RULEBOOK.md
 2. LOCALRULES.md
 3. skills/session-init/SKILL.md
 
 ## Bootstrap Rule
 
-The agentic framework lives under `.ai/` and is managed by `gh agentic mount`.
+The agentic framework lives under `.agents/` and is managed by `gh agentic mount`.
 The directory is gitignored — every fresh clone, worktree, or CI checkout
 starts without it. Mounting is therefore **step zero of every session**, before
 any other initialisation.
@@ -16,10 +16,10 @@ any other initialisation.
 
 Run these checks at session start, in order, **before** invoking `session-init`:
 
-1. **Mount is missing.** If `.ai/` does not exist, run `gh agentic mount`
+1. **Mount is missing.** If `.agents/` does not exist, run `gh agentic mount`
    and proceed. Do not ask — mounting is idempotent and side-effect-free.
 
-2. **Mount is stale.** If `.ai/` exists, run `gh agentic info` and compare
+2. **Mount is stale.** If `.agents/` exists, run `gh agentic info` and compare
    the reported `Framework (local)` version against the repo variable
    `AGENTIC_FRAMEWORK_VERSION` (if set). If they differ, run
    `gh agentic mount <AGENTIC_FRAMEWORK_VERSION>` to sync, then proceed.
@@ -30,7 +30,7 @@ Run these checks at session start, in order, **before** invoking `session-init`:
    - **CI context:** fail the job with the same error and the message
      `"Framework mount failed — add a mount step before the pipeline."`
 
-4. **Mount is healthy.** Invoke `session-init` as defined in `.ai/skills/session-init.md`.
+4. **Mount is healthy.** Invoke `session-init` as defined in `.agents/skills/session-init.md`.
 
 ### Why this is proactive
 


### PR DESCRIPTION
## Summary

- Removes the `.ai` submodule (old framework mount point)
- Updates `AGENTS.md` to reference `.agents/` throughout
- `.agents` submodule (v2.8.1) remains as the sole framework mount point