### PR TITLE
ci: drop macOS Intel (macos-13) build from release matrix

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,7 +11,6 @@
 #
 # Artefacts produced:
 #   ocs-testbench-darwin-arm64.zip  — macOS .app bundle (Apple Silicon)
-#   ocs-testbench-darwin-amd64.zip  — macOS .app bundle (Intel)
 #   ocs-testbench-windows-amd64.zip — Windows .exe (Wails / WebView2)
 #   ocs-testbench-linux-amd64.tar.gz — headless server binary (no WebKitGTK)
 #
@@ -40,11 +39,6 @@ jobs:
           - name:     macOS arm64
             os:       macos-latest      # Apple Silicon runner
             artifact: ocs-testbench-darwin-arm64.zip
-            wails:    true
-
-          - name:     macOS amd64
-            os:       macos-13          # last Intel runner
-            artifact: ocs-testbench-darwin-amd64.zip
             wails:    true
 
           - name:     Windows amd64
@@ -156,7 +150,6 @@ jobs:
             --title "Release ${{ github.ref_name }}" \
             --notes "Generating release notes…" \
             ocs-testbench-darwin-arm64.zip \
-            ocs-testbench-darwin-amd64.zip \
             ocs-testbench-windows-amd64.zip \
             ocs-testbench-linux-amd64.tar.gz
         env:


### PR DESCRIPTION
## Summary

- Removes the `macos-13` (Intel) matrix entry from the release builder
- `macos-13` runners are scarce and block releases indefinitely
- Apple Silicon (`macos-latest`) build covers the vast majority of current Mac users

## Retrigger after merge
Delete and re-push the tag to kick off a clean release run:
```bash
git tag -d v1.0.0 && git push origin --delete v1.0.0
git tag v1.0.0 && git push origin v1.0.0
```