### PR TITLE
fix: pre-arm CloseNotifier before StateConnected to prevent waitForDrop hang

### DIFF
--- a/internal/diameter/conn/connection.go
+++ b/internal/diameter/conn/connection.go
@@ -375,6 +375,15 @@ func (pc *PeerConnection) run(ctx context.Context) {
 		pc.muLife.Lock()
 		pc.activeConn = c
 		pc.muLife.Unlock()
+		// Pre-arm the close-notifier channel before emitting StateConnected.
+		// go-diameter's notifyClientGone only closes closeNotifyc when it is
+		// non-nil; if a subscriber closes the connection immediately upon
+		// receiving StateConnected, c.serve() can exit before waitForDrop
+		// calls CloseNotify(), leaving closeNotifyc nil and the goroutine
+		// hanging until the context is cancelled.
+		if cn, ok := c.(diam.CloseNotifier); ok {
+			_ = cn.CloseNotify()
+		}
 		pc.transitionTo(diameter.StateConnected, "CER/CEA OK")
 		backoff = pc.backoffInitial
 


### PR DESCRIPTION
## Summary

- Fixes a race condition in `internal/diameter/conn/connection.go` causing `TestPeerConnection_BackoffLoopKeepsTicking` to hang for 15s in CI
- The test reported `timeout 15s waiting for state disconnected; saw []`

## Root cause

`go-diameter`'s `notifyClientGone()` only closes `closeNotifyc` if it is non-nil. `closeNotifyc` is created on the first call to `CloseNotify()`.

If a subscriber closes the connection immediately on receiving `StateConnected` (as the test does), `c.serve()` can exit and call `notifyClientGone()` before `waitForDrop` has called `CloseNotify()`. This leaves `closeNotifyc` nil, so `notifyClientGone()` does nothing. `waitForDrop` then creates the channel fresh — but it's never closed, so it hangs until context cancellation.

## Fix

Call `CloseNotify()` once immediately after the connection is established and stored, **before** emitting `StateConnected`. This guarantees `closeNotifyc` exists before any subscriber can react to the event and close the connection.

## Test plan

- [ ] `go test ./internal/diameter/conn/... -run TestPeerConnection_BackoffLoopKeepsTicking -count=10` — passes 10/10 locally (was flaky in CI)
- [ ] Full `go test ./internal/diameter/conn/...` — all 13 tests pass

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)