### PR TITLE
chore: bump agentic framework to v2.8.3

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   pipeline:
-    uses: eddiecarpenter/gh-agentic/.github/workflows/agentic-pipeline.yml@v2.8.2
+    uses: eddiecarpenter/gh-agentic/.github/workflows/agentic-pipeline.yml@v2.8.3
     with:
       pr_number: ${{ inputs.pr_number || '' }}
       branch_name: ${{ inputs.branch_name || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    uses: eddiecarpenter/gh-agentic/.github/workflows/release.yml@v2.8.2
+    uses: eddiecarpenter/gh-agentic/.github/workflows/release.yml@v2.8.3
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
Upgrades the agentic framework from v2.8.2 to v2.8.3 (hotfix for error in v2.8.2).

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)