### PR TITLE
MCP server: envelope responses, new tools, and AVP children lookup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "enabledMcpjsonServers": ["ocs-testbench"]
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "ocs-testbench": {
+      "type": "http",
+      "url": "http://localhost:8080/mcp"
+    }
+  }
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -69,9 +69,9 @@ func postJSONWithSessionID(t *testing.T, client *http.Client, url string, body a
 	return resp, rpcResp
 }
 
-// TestNewServer_ToolListReturns33Tools verifies AC-1: the tool-list request
-// returns exactly 33 tools with non-empty names and correct hint annotations.
-func TestNewServer_ToolListReturns33Tools(t *testing.T) {
+// TestNewServer_ToolListReturns34Tools verifies AC-1: the tool-list request
+// returns exactly 34 tools with non-empty names and correct hint annotations.
+func TestNewServer_ToolListReturns34Tools(t *testing.T) {
 	handler := newTestMCPServer()
 	require.NotNil(t, handler, "NewServer must return a non-nil handler")
 
@@ -111,7 +111,7 @@ func TestNewServer_ToolListReturns33Tools(t *testing.T) {
 
 	tools, ok := listRPCResp.Result["tools"].([]any)
 	require.True(t, ok, "result.tools must be an array, got: %T", listRPCResp.Result["tools"])
-	assert.Len(t, tools, 33, "exactly 33 tools must be registered")
+	assert.Len(t, tools, 34, "exactly 34 tools must be registered")
 
 	// Build a name→annotations map for spot-check assertions.
 	type toolAnnotations struct {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -69,9 +69,9 @@ func postJSONWithSessionID(t *testing.T, client *http.Client, url string, body a
 	return resp, rpcResp
 }
 
-// TestNewServer_ToolListReturns32Tools verifies AC-1: the tool-list request
-// returns exactly 32 tools with non-empty names and correct hint annotations.
-func TestNewServer_ToolListReturns32Tools(t *testing.T) {
+// TestNewServer_ToolListReturns33Tools verifies AC-1: the tool-list request
+// returns exactly 33 tools with non-empty names and correct hint annotations.
+func TestNewServer_ToolListReturns33Tools(t *testing.T) {
 	handler := newTestMCPServer()
 	require.NotNil(t, handler, "NewServer must return a non-nil handler")
 
@@ -111,7 +111,7 @@ func TestNewServer_ToolListReturns32Tools(t *testing.T) {
 
 	tools, ok := listRPCResp.Result["tools"].([]any)
 	require.True(t, ok, "result.tools must be an array, got: %T", listRPCResp.Result["tools"])
-	assert.Len(t, tools, 32, "exactly 32 tools must be registered")
+	assert.Len(t, tools, 33, "exactly 33 tools must be registered")
 
 	// Build a name→annotations map for spot-check assertions.
 	type toolAnnotations struct {

--- a/internal/mcp/tools_avp.go
+++ b/internal/mcp/tools_avp.go
@@ -23,7 +23,7 @@ func registerAVPTools(s *server.MCPServer, srv *Server) {
 	// get_avp_info — read-only
 	s.AddTool(
 		mcp.NewTool("get_avp_info",
-			mcp.WithDescription("Get detailed information about a specific AVP: name, code, vendor ID, and Diameter data type."),
+			mcp.WithDescription("Get detailed information about a specific AVP: name, code, vendor ID, Diameter data type, and child AVPs for Grouped types."),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),
 			mcp.WithString("name",
@@ -36,11 +36,13 @@ func registerAVPTools(s *server.MCPServer, srv *Server) {
 }
 
 // avpInfoJSON is the MCP response shape for a single AVP.
+// For Grouped AVPs, Children lists the member AVPs defined in the dictionary.
 type avpInfoJSON struct {
-	Name     string `json:"name"`
-	Code     uint32 `json:"code"`
-	VendorID uint32 `json:"vendorId,omitempty"`
-	DataType string `json:"dataType"`
+	Name     string        `json:"name"`
+	Code     uint32        `json:"code"`
+	VendorID uint32        `json:"vendorId,omitempty"`
+	DataType string        `json:"dataType"`
+	Children []avpInfoJSON `json:"children,omitempty"`
 }
 
 // handleListAVPs returns all known AVPs from the Diameter dictionary.
@@ -73,6 +75,8 @@ func (srv *Server) handleListAVPs(ctx context.Context, req mcp.CallToolRequest) 
 }
 
 // handleGetAVPInfo returns metadata for a named AVP.
+// For Grouped AVPs the response includes a children array listing every
+// member AVP defined by the dictionary rules for that group.
 func (srv *Server) handleGetAVPInfo(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	name, err := req.RequireString("name")
 	if err != nil {
@@ -88,10 +92,39 @@ func (srv *Server) handleGetAVPInfo(ctx context.Context, req mcp.CallToolRequest
 		return mcp.NewToolResultError(fmt.Sprintf("AVP %q not found in dictionary", name)), nil
 	}
 
-	return mcp.NewToolResultJSON(avpInfoJSON{
+	result := avpInfoJSON{
 		Name:     name,
 		Code:     meta.Code,
 		VendorID: meta.VendorID,
 		DataType: meta.DataType,
-	})
+	}
+
+	// For Grouped AVPs, resolve the child AVPs from the parser's rule list.
+	if meta.DataType == "Grouped" && srv.parser != nil {
+		for _, app := range srv.parser.Apps() {
+			for _, avp := range app.AVP {
+				if avp.Name != name {
+					continue
+				}
+				for _, rule := range avp.Data.Rule {
+					childMeta, childErr := srv.dict.Lookup(rule.AVP)
+					if childErr != nil {
+						// Include partial info even if the child isn't in the
+						// high-level dictionary (e.g. vendor-specific sub-AVPs).
+						result.Children = append(result.Children, avpInfoJSON{Name: rule.AVP})
+						continue
+					}
+					result.Children = append(result.Children, avpInfoJSON{
+						Name:     rule.AVP,
+						Code:     childMeta.Code,
+						VendorID: childMeta.VendorID,
+						DataType: childMeta.DataType,
+					})
+				}
+				break
+			}
+		}
+	}
+
+	return mcp.NewToolResultJSON(result)
 }

--- a/internal/mcp/tools_avp.go
+++ b/internal/mcp/tools_avp.go
@@ -47,7 +47,7 @@ type avpInfoJSON struct {
 // When the parser is nil (e.g. in tests), returns an empty list.
 func (srv *Server) handleListAVPs(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	if srv.parser == nil {
-		return mcp.NewToolResultJSON([]avpInfoJSON{})
+		return mcp.NewToolResultJSON(map[string]any{"avps": []avpInfoJSON{}})
 	}
 
 	// Iterate all applications in the parser and collect unique AVPs by name.
@@ -69,7 +69,7 @@ func (srv *Server) handleListAVPs(ctx context.Context, req mcp.CallToolRequest) 
 		}
 	}
 
-	return mcp.NewToolResultJSON(avps)
+	return mcp.NewToolResultJSON(map[string]any{"avps": avps})
 }
 
 // handleGetAVPInfo returns metadata for a named AVP.

--- a/internal/mcp/tools_avp_system_test.go
+++ b/internal/mcp/tools_avp_system_test.go
@@ -41,9 +41,10 @@ func TestHandleListAVPs_NilParser_ReturnsEmpty(t *testing.T) {
 	client := newMCPTestClient(t, store.NewTestStore())
 	resp := client.callTool("list_avps", nil)
 
-	var result []any
-	toolResult(t, resp, &result)
-	assert.Empty(t, result, "nil parser must return empty AVP list")
+	var envelope map[string]any
+	toolResult(t, resp, &envelope)
+	avps, _ := envelope["avps"].([]any)
+	assert.Empty(t, avps, "nil parser must return empty AVP list")
 }
 
 // TestHandleGetAVPInfo_NilDict_ReturnsToolError verifies get_avp_info with nil dict.

--- a/internal/mcp/tools_executions.go
+++ b/internal/mcp/tools_executions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -11,7 +12,7 @@ import (
 	"github.com/eddiecarpenter/ocs-testbench/internal/api"
 )
 
-// registerExecutionTools registers all 9 execution control tools.
+// registerExecutionTools registers all 10 execution control tools.
 func registerExecutionTools(s *server.MCPServer, srv *Server) {
 	// start_execution — write, non-destructive
 	s.AddTool(
@@ -137,6 +138,25 @@ func registerExecutionTools(s *server.MCPServer, srv *Server) {
 		srv.handleApplyContextOverride,
 	)
 
+	// wait_execution — read-only, blocking
+	s.AddTool(
+		mcp.NewTool("wait_execution",
+			mcp.WithDescription("Block until an execution session reaches a terminal state (success, error, terminated) "+
+				"or the timeout expires. Returns the final execution detail. "+
+				"Use after start_execution in continuous mode to avoid polling."),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithString("session_id",
+				mcp.Required(),
+				mcp.Description("Session ID of the execution to wait for."),
+			),
+			mcp.WithNumber("timeout_seconds",
+				mcp.Description("Maximum seconds to wait before returning (default 120, max 600)."),
+			),
+		),
+		srv.handleWaitExecution,
+	)
+
 	// apply_execution_payload_override — write, non-destructive
 	s.AddTool(
 		mcp.NewTool("apply_execution_payload_override",
@@ -223,14 +243,14 @@ func (srv *Server) handleStartExecution(ctx context.Context, req mcp.CallToolReq
 // handleListExecutions lists all execution sessions.
 func (srv *Server) handleListExecutions(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	if srv.execEngine == nil {
-		return mcp.NewToolResultJSON([]executionSummaryMCPJSON{})
+		return mcp.NewToolResultJSON(map[string]any{"executions": []executionSummaryMCPJSON{}})
 	}
 	sessions := srv.execEngine.List(ctx)
 	out := make([]executionSummaryMCPJSON, len(sessions))
 	for i, s := range sessions {
 		out[i] = toExecutionSummaryMCP(s)
 	}
-	return mcp.NewToolResultJSON(out)
+	return mcp.NewToolResultJSON(map[string]any{"executions": out})
 }
 
 // handleGetExecution gets the current state of an execution.
@@ -397,4 +417,54 @@ func (srv *Server) handleApplyPayloadOverride(ctx context.Context, req mcp.CallT
 		"sessionId": sessionID,
 		"variables": variables,
 	})
+}
+
+// handleWaitExecution blocks until the execution session reaches a terminal
+// state (success, error, terminated) or the timeout expires, then returns
+// the final execution detail. This avoids the need to poll get_execution.
+func (srv *Server) handleWaitExecution(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if srv.execEngine == nil {
+		return mcp.NewToolResultError("execution engine not available"), nil
+	}
+	sessionID, err := req.RequireString("session_id")
+	if err != nil {
+		return mcp.NewToolResultError("session_id is required"), nil
+	}
+
+	timeoutSecs := req.GetFloat("timeout_seconds", 120)
+	if timeoutSecs <= 0 || timeoutSecs > 600 {
+		timeoutSecs = 120
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSecs)*time.Second)
+	defer cancel()
+
+	events, subErr := srv.execEngine.Subscribe(waitCtx, sessionID)
+	if subErr != nil {
+		if errors.Is(subErr, api.ErrSessionNotFound) {
+			return mcp.NewToolResultError(fmt.Sprintf("session %q not found", sessionID)), nil
+		}
+		return mcp.NewToolResultError(fmt.Sprintf("subscribe failed: %v", subErr)), nil
+	}
+
+	// Drain events until the channel closes (terminal state) or timeout fires.
+	for range events {
+	}
+
+	// Context deadline exceeded — session did not reach a terminal state in time.
+	if waitCtx.Err() != nil {
+		return mcp.NewToolResultError(fmt.Sprintf(
+			"session %q did not complete within %.0f seconds", sessionID, timeoutSecs,
+		)), nil
+	}
+
+	// Session is terminal — return final detail.
+	detail, detailErr := srv.execEngine.Detail(ctx, sessionID)
+	if detailErr != nil {
+		if errors.Is(detailErr, api.ErrSessionNotFound) {
+			return mcp.NewToolResultError(fmt.Sprintf("session %q not found", sessionID)), nil
+		}
+		return mcp.NewToolResultError(fmt.Sprintf("get execution detail failed: %v", detailErr)), nil
+	}
+	return mcp.NewToolResultJSON(detail)
 }

--- a/internal/mcp/tools_executions.go
+++ b/internal/mcp/tools_executions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -12,7 +13,7 @@ import (
 	"github.com/eddiecarpenter/ocs-testbench/internal/api"
 )
 
-// registerExecutionTools registers all 10 execution control tools.
+// registerExecutionTools registers all 11 execution control tools.
 func registerExecutionTools(s *server.MCPServer, srv *Server) {
 	// start_execution — write, non-destructive
 	s.AddTool(
@@ -117,6 +118,26 @@ func registerExecutionTools(s *server.MCPServer, srv *Server) {
 			),
 		),
 		srv.handleGetExecutionDetail,
+	)
+
+	// get_step_detail — read-only
+	s.AddTool(
+		mcp.NewTool("get_step_detail",
+			mcp.WithDescription("Get the CCR/CCA AVP detail for a single step of an execution session. "+
+				"Returns structured AVP lines for both the request and the answer, "+
+				"plus result code, duration, and state."),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithString("session_id",
+				mcp.Required(),
+				mcp.Description("Session ID of the execution."),
+			),
+			mcp.WithNumber("step",
+				mcp.Required(),
+				mcp.Description("1-based step number to retrieve (e.g. 1 = first step, 2 = second step)."),
+			),
+		),
+		srv.handleGetStepDetail,
 	)
 
 	// apply_execution_context_override — write, non-destructive
@@ -467,4 +488,76 @@ func (srv *Server) handleWaitExecution(ctx context.Context, req mcp.CallToolRequ
 		return mcp.NewToolResultError(fmt.Sprintf("get execution detail failed: %v", detailErr)), nil
 	}
 	return mcp.NewToolResultJSON(detail)
+}
+
+// handleGetStepDetail returns the CCR/CCA AVP detail for a single step.
+func (srv *Server) handleGetStepDetail(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if srv.execEngine == nil {
+		return mcp.NewToolResultError("execution engine not available"), nil
+	}
+	sessionID, err := req.RequireString("session_id")
+	if err != nil {
+		return mcp.NewToolResultError("session_id is required"), nil
+	}
+	stepNum := int(req.GetFloat("step", 0))
+	if stepNum < 1 {
+		return mcp.NewToolResultError("step must be a 1-based step number (e.g. 1, 2, 3)"), nil
+	}
+
+	detail, detailErr := srv.execEngine.Detail(ctx, sessionID)
+	if detailErr != nil {
+		if errors.Is(detailErr, api.ErrSessionNotFound) {
+			return mcp.NewToolResultError(fmt.Sprintf("session %q not found", sessionID)), nil
+		}
+		return mcp.NewToolResultError(fmt.Sprintf("get execution detail failed: %v", detailErr)), nil
+	}
+
+	if stepNum > len(detail.Steps) {
+		return mcp.NewToolResultError(fmt.Sprintf(
+			"step %d out of range — session has %d step(s)", stepNum, len(detail.Steps),
+		)), nil
+	}
+
+	step := detail.Steps[stepNum-1]
+	return mcp.NewToolResultJSON(map[string]any{
+		"n":           step.N,
+		"label":       step.Label,
+		"requestType": step.RequestType,
+		"state":       step.State,
+		"durationMs":  step.DurationMs,
+		"resultCode":  step.Response["resultCode"],
+		"request":     parseAVPText(step.RequestText),
+		"response":    parseAVPText(step.ResponseText),
+	})
+}
+
+// parseAVPText converts the human-readable Diameter AVP text into a slice
+// of structured {code, name, value} objects for easy consumption.
+func parseAVPText(raw string) []map[string]string {
+	var avps []map[string]string
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "Diameter Message:") {
+			continue
+		}
+		// Format: "  264: Origin-Host. . . . . . ocsclient:1812"
+		colonIdx := strings.Index(line, ":")
+		if colonIdx < 0 {
+			continue
+		}
+		code := strings.TrimSpace(line[:colonIdx])
+		rest := strings.TrimSpace(line[colonIdx+1:])
+		// Split name from value on the dot-leader sequence
+		dotIdx := strings.Index(rest, ". ")
+		if dotIdx < 0 {
+			// Grouped AVP line with no value
+			avps = append(avps, map[string]string{"code": code, "name": strings.TrimRight(rest, ". "), "value": "<Grouped>"})
+			continue
+		}
+		name := strings.TrimRight(rest[:dotIdx], ". ")
+		value := strings.TrimSpace(rest[dotIdx:])
+		value = strings.TrimLeft(value, ". ")
+		avps = append(avps, map[string]string{"code": code, "name": name, "value": value})
+	}
+	return avps
 }

--- a/internal/mcp/tools_executions_test.go
+++ b/internal/mcp/tools_executions_test.go
@@ -357,3 +357,77 @@ func TestHandleWaitExecution_MissingSessionID_ReturnsToolError(t *testing.T) {
 	resp := client.callTool("wait_execution", map[string]any{})
 	assert.True(t, isToolError(resp), "missing session_id must return isError: true")
 }
+
+// TestHandleGetStepDetail_ReturnsStep verifies get_step_detail returns structured
+// AVP data for a specific step number.
+func TestHandleGetStepDetail_ReturnsStep(t *testing.T) {
+	exec := newFakeEngine()
+	client := newMCPClientWithExecEngine(t, exec)
+
+	startResp := client.callTool("start_execution", map[string]any{
+		"scenario_id": "scenario-step-detail",
+		"mode":        "interactive",
+	})
+	var started map[string]any
+	toolResult(t, startResp, &started)
+	sessionID, _ := started["id"].(string)
+	require.NotEmpty(t, sessionID)
+
+	exec.seedStep(sessionID, api.StepRecordJSON{
+		N:           1,
+		Kind:        "request",
+		RequestType: "INITIAL",
+		Label:       "CCR-INITIAL",
+		State:       "success",
+		DurationMs:  12,
+		Request:     map[string]any{"resultCode": float64(0)},
+		Response:    map[string]any{"resultCode": float64(2001)},
+		RequestText: "Diameter Message: CommandCode: 272, appId: 4, flags: 128\n264: Origin-Host. . . . . . ocsclient:1812\n",
+		ResponseText: "Diameter Message: CommandCode: 272, appId: 4, flags: 0\n268: Result-Code. . . . . . 2001\n",
+	})
+
+	resp := client.callTool("get_step_detail", map[string]any{
+		"session_id": sessionID,
+		"step":       float64(1),
+	})
+	var result map[string]any
+	toolResult(t, resp, &result)
+	assert.Equal(t, float64(1), result["n"])
+	assert.Equal(t, "CCR-INITIAL", result["label"])
+	assert.Equal(t, float64(2001), result["resultCode"])
+	request, _ := result["request"].([]any)
+	assert.NotEmpty(t, request, "request AVPs must be present")
+	response, _ := result["response"].([]any)
+	assert.NotEmpty(t, response, "response AVPs must be present")
+}
+
+// TestHandleGetStepDetail_OutOfRange_ReturnsToolError verifies AC-4.
+func TestHandleGetStepDetail_OutOfRange_ReturnsToolError(t *testing.T) {
+	exec := newFakeEngine()
+	client := newMCPClientWithExecEngine(t, exec)
+
+	startResp := client.callTool("start_execution", map[string]any{
+		"scenario_id": "scenario-oob",
+		"mode":        "interactive",
+	})
+	var started map[string]any
+	toolResult(t, startResp, &started)
+	sessionID, _ := started["id"].(string)
+
+	resp := client.callTool("get_step_detail", map[string]any{
+		"session_id": sessionID,
+		"step":       float64(99),
+	})
+	assert.True(t, isToolError(resp), "out-of-range step must return isError: true")
+}
+
+// TestHandleGetStepDetail_MissingStep_ReturnsToolError verifies AC-4.
+func TestHandleGetStepDetail_MissingStep_ReturnsToolError(t *testing.T) {
+	exec := newFakeEngine()
+	client := newMCPClientWithExecEngine(t, exec)
+	resp := client.callTool("get_step_detail", map[string]any{
+		"session_id": "any",
+		"step":       float64(0),
+	})
+	assert.True(t, isToolError(resp), "step=0 must return isError: true")
+}

--- a/internal/mcp/tools_executions_test.go
+++ b/internal/mcp/tools_executions_test.go
@@ -78,7 +78,10 @@ func (f *fakeExecutionEngine) Detail(_ context.Context, sessionID string) (api.E
 	return d, nil
 }
 
-func (f *fakeExecutionEngine) Subscribe(_ context.Context, _ string) (<-chan api.ExecutionEvent, error) {
+func (f *fakeExecutionEngine) Subscribe(_ context.Context, sessionID string) (<-chan api.ExecutionEvent, error) {
+	if _, ok := f.sessions[sessionID]; !ok {
+		return nil, api.ErrSessionNotFound
+	}
 	ch := make(chan api.ExecutionEvent)
 	close(ch)
 	return ch, nil
@@ -145,9 +148,10 @@ func newMCPClientWithExecEngine(t *testing.T, exec api.ExecutionEngine) *mcpTest
 func TestHandleListExecutions_EmptyList(t *testing.T) {
 	client := newMCPTestClient(t, store.NewTestStore())
 	resp := client.callTool("list_executions", nil)
-	var result []any
-	toolResult(t, resp, &result)
-	assert.Empty(t, result, "empty engine must return empty list")
+	var envelope map[string]any
+	toolResult(t, resp, &envelope)
+	executions, _ := envelope["executions"].([]any)
+	assert.Empty(t, executions, "empty engine must return empty list")
 }
 
 // TestHandleGetExecution_MissingSessionID_ReturnsToolError verifies AC-4.
@@ -309,4 +313,47 @@ func TestHandleApplyContextOverride_MissingVariables_ReturnsToolError(t *testing
 		"session_id": sessionID,
 	})
 	assert.True(t, isToolError(resp), "missing variables must return isError: true")
+}
+
+// TestHandleWaitExecution_CompletedSession_ReturnsDetail verifies that
+// wait_execution returns the final execution detail when the session is
+// already terminal (channel closed immediately by fakeExecutionEngine).
+func TestHandleWaitExecution_CompletedSession_ReturnsDetail(t *testing.T) {
+	exec := newFakeEngine()
+	client := newMCPClientWithExecEngine(t, exec)
+
+	startResp := client.callTool("start_execution", map[string]any{
+		"scenario_id": "scenario-wait",
+		"mode":        "continuous",
+	})
+	var started map[string]any
+	toolResult(t, startResp, &started)
+	sessionID, _ := started["id"].(string)
+	require.NotEmpty(t, sessionID)
+
+	resp := client.callTool("wait_execution", map[string]any{
+		"session_id":     sessionID,
+		"timeout_seconds": 10,
+	})
+	var detail map[string]any
+	toolResult(t, resp, &detail)
+	assert.Equal(t, sessionID, detail["id"], "wait_execution must return final execution detail")
+}
+
+// TestHandleWaitExecution_UnknownSession_ReturnsToolError verifies AC-4.
+func TestHandleWaitExecution_UnknownSession_ReturnsToolError(t *testing.T) {
+	exec := newFakeEngine()
+	client := newMCPClientWithExecEngine(t, exec)
+	resp := client.callTool("wait_execution", map[string]any{
+		"session_id": "00000000-0000-0000-0000-000000000000",
+	})
+	assert.True(t, isToolError(resp), "unknown session must return isError: true")
+}
+
+// TestHandleWaitExecution_MissingSessionID_ReturnsToolError verifies AC-4.
+func TestHandleWaitExecution_MissingSessionID_ReturnsToolError(t *testing.T) {
+	exec := newFakeEngine()
+	client := newMCPClientWithExecEngine(t, exec)
+	resp := client.callTool("wait_execution", map[string]any{})
+	assert.True(t, isToolError(resp), "missing session_id must return isError: true")
 }

--- a/internal/mcp/tools_executions_test.go
+++ b/internal/mcp/tools_executions_test.go
@@ -332,7 +332,7 @@ func TestHandleWaitExecution_CompletedSession_ReturnsDetail(t *testing.T) {
 	require.NotEmpty(t, sessionID)
 
 	resp := client.callTool("wait_execution", map[string]any{
-		"session_id":     sessionID,
+		"session_id":      sessionID,
 		"timeout_seconds": 10,
 	})
 	var detail map[string]any
@@ -374,15 +374,15 @@ func TestHandleGetStepDetail_ReturnsStep(t *testing.T) {
 	require.NotEmpty(t, sessionID)
 
 	exec.seedStep(sessionID, api.StepRecordJSON{
-		N:           1,
-		Kind:        "request",
-		RequestType: "INITIAL",
-		Label:       "CCR-INITIAL",
-		State:       "success",
-		DurationMs:  12,
-		Request:     map[string]any{"resultCode": float64(0)},
-		Response:    map[string]any{"resultCode": float64(2001)},
-		RequestText: "Diameter Message: CommandCode: 272, appId: 4, flags: 128\n264: Origin-Host. . . . . . ocsclient:1812\n",
+		N:            1,
+		Kind:         "request",
+		RequestType:  "INITIAL",
+		Label:        "CCR-INITIAL",
+		State:        "success",
+		DurationMs:   12,
+		Request:      map[string]any{"resultCode": float64(0)},
+		Response:     map[string]any{"resultCode": float64(2001)},
+		RequestText:  "Diameter Message: CommandCode: 272, appId: 4, flags: 128\n264: Origin-Host. . . . . . ocsclient:1812\n",
 		ResponseText: "Diameter Message: CommandCode: 272, appId: 4, flags: 0\n268: Result-Code. . . . . . 2001\n",
 	})
 

--- a/internal/mcp/tools_peers.go
+++ b/internal/mcp/tools_peers.go
@@ -29,12 +29,14 @@ func registerPeerTools(s *server.MCPServer, srv *Server) {
 	// get_peer — read-only
 	s.AddTool(
 		mcp.NewTool("get_peer",
-			mcp.WithDescription("Get a single Diameter peer by ID."),
+			mcp.WithDescription("Get a single Diameter peer by UUID or name. Provide either 'id' or 'name'; if both are given, 'id' takes precedence."),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),
 			mcp.WithString("id",
-				mcp.Required(),
 				mcp.Description("UUID of the peer to retrieve."),
+			),
+			mcp.WithString("name",
+				mcp.Description("Unique name of the peer to retrieve (e.g. 'OpenBSS')."),
 			),
 		),
 		srv.handleGetPeer,
@@ -214,23 +216,39 @@ func (srv *Server) handleListPeers(ctx context.Context, req mcp.CallToolRequest)
 	for i, p := range peers {
 		out[i] = srv.toPeerJSON(p)
 	}
-	return mcp.NewToolResultJSON(out)
+	return mcp.NewToolResultJSON(map[string]any{"peers": out})
 }
 
-// handleGetPeer returns a single peer by UUID.
+// handleGetPeer returns a single peer by UUID or name.
+// If 'id' is provided it takes precedence; otherwise 'name' is used.
 func (srv *Server) handleGetPeer(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	idStr, err := req.RequireString("id")
-	if err != nil {
-		return mcp.NewToolResultError("id is required"), nil
+	idStr := req.GetString("id", "")
+	name := req.GetString("name", "")
+
+	if idStr == "" && name == "" {
+		return mcp.NewToolResultError("either 'id' or 'name' is required"), nil
 	}
-	id, err := parseUUID(idStr)
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("invalid peer id %q: %v", idStr, err)), nil
+
+	if idStr != "" {
+		id, err := parseUUID(idStr)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("invalid peer id %q: %v", idStr, err)), nil
+		}
+		peer, err := srv.store.GetPeer(ctx, id)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				return mcp.NewToolResultError(fmt.Sprintf("peer %q not found", idStr)), nil
+			}
+			return mcp.NewToolResultError(fmt.Sprintf("get peer failed: %v", err)), nil
+		}
+		return mcp.NewToolResultJSON(srv.toPeerJSON(peer))
 	}
-	peer, err := srv.store.GetPeer(ctx, id)
+
+	// Lookup by name.
+	peer, err := srv.store.GetPeerByName(ctx, name)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
-			return mcp.NewToolResultError(fmt.Sprintf("peer %q not found", idStr)), nil
+			return mcp.NewToolResultError(fmt.Sprintf("peer %q not found", name)), nil
 		}
 		return mcp.NewToolResultError(fmt.Sprintf("get peer failed: %v", err)), nil
 	}

--- a/internal/mcp/tools_peers_test.go
+++ b/internal/mcp/tools_peers_test.go
@@ -109,11 +109,12 @@ func TestHandleListPeers_ReturnsPeers(t *testing.T) {
 	client := newMCPTestClient(t, s)
 	resp := client.callTool("list_peers", nil)
 
-	var peers []map[string]any
-	toolResult(t, resp, &peers)
+	var envelope map[string]any
+	toolResult(t, resp, &envelope)
+	peers, _ := envelope["peers"].([]any)
 	assert.Len(t, peers, 2, "list_peers must return 2 peers")
-	assert.Equal(t, "ocs-01", peers[0]["name"])
-	assert.Equal(t, "ocs-02", peers[1]["name"])
+	assert.Equal(t, "ocs-01", peers[0].(map[string]any)["name"])
+	assert.Equal(t, "ocs-02", peers[1].(map[string]any)["name"])
 }
 
 // TestHandleGetPeer_ExistingPeer_ReturnsIt verifies get_peer with a valid ID.
@@ -146,13 +147,29 @@ func TestHandleGetPeer_MissingPeer_ReturnsToolError(t *testing.T) {
 	assert.Contains(t, errMsg, "not found", "error message must mention not found")
 }
 
-// TestHandleGetPeer_MissingRequiredParam_ReturnsToolError verifies AC-4:
-// missing required params return structured tool errors (not panics).
+// TestHandleGetPeer_ByName_ReturnsIt verifies get_peer resolves by name.
+func TestHandleGetPeer_ByName_ReturnsIt(t *testing.T) {
+	s := store.NewTestStore()
+	ctx := context.Background()
+	_, err := s.InsertPeer(ctx, "ocs-01", []byte(`{"host":"10.0.0.1","port":3868}`))
+	require.NoError(t, err)
+
+	client := newMCPTestClient(t, s)
+	resp := client.callTool("get_peer", map[string]any{"name": "ocs-01"})
+
+	var result map[string]any
+	toolResult(t, resp, &result)
+	assert.Equal(t, "ocs-01", result["name"])
+	assert.Equal(t, "10.0.0.1", result["host"])
+}
+
+// TestHandleGetPeer_MissingRequiredParam_ReturnsToolError verifies that
+// calling get_peer with neither id nor name returns a structured tool error.
 func TestHandleGetPeer_MissingRequiredParam_ReturnsToolError(t *testing.T) {
 	client := newMCPTestClient(t, store.NewTestStore())
-	// Call without id parameter.
+	// Call without id or name parameter.
 	resp := client.callTool("get_peer", map[string]any{})
-	assert.True(t, isToolError(resp), "missing id param must return isError: true")
+	assert.True(t, isToolError(resp), "missing id and name must return isError: true")
 }
 
 // TestHandleCreatePeer_ValidInput_ReturnsPeer verifies create_peer creates a peer.

--- a/internal/mcp/tools_scenarios.go
+++ b/internal/mcp/tools_scenarios.go
@@ -255,7 +255,7 @@ func (srv *Server) handleListScenarios(ctx context.Context, req mcp.CallToolRequ
 	for i, sc := range scenarios {
 		out[i] = toScenarioSummaryJSON(sc)
 	}
-	return mcp.NewToolResultJSON(out)
+	return mcp.NewToolResultJSON(map[string]any{"scenarios": out})
 }
 
 // handleGetScenario returns a single scenario by UUID.

--- a/internal/mcp/tools_scenarios_test.go
+++ b/internal/mcp/tools_scenarios_test.go
@@ -66,8 +66,9 @@ func TestHandleListScenarios_ReturnsAll(t *testing.T) {
 	client := newMCPTestClient(t, f.s)
 	resp := client.callTool("list_scenarios", nil)
 
-	var scenarios []map[string]any
-	toolResult(t, resp, &scenarios)
+	var envelope map[string]any
+	toolResult(t, resp, &envelope)
+	scenarios, _ := envelope["scenarios"].([]any)
 	assert.Len(t, scenarios, 2, "list_scenarios must return 2 scenarios")
 }
 

--- a/internal/mcp/tools_subscribers.go
+++ b/internal/mcp/tools_subscribers.go
@@ -152,7 +152,7 @@ func (srv *Server) handleListSubscribers(ctx context.Context, req mcp.CallToolRe
 	for i, s := range subs {
 		out[i] = toSubscriberJSON(s)
 	}
-	return mcp.NewToolResultJSON(out)
+	return mcp.NewToolResultJSON(map[string]any{"subscribers": out})
 }
 
 // handleGetSubscriber returns a single subscriber by UUID.

--- a/internal/mcp/tools_subscribers_test.go
+++ b/internal/mcp/tools_subscribers_test.go
@@ -28,8 +28,9 @@ func TestHandleListSubscribers_ReturnsSubscribers(t *testing.T) {
 	client := newMCPTestClient(t, s)
 	resp := client.callTool("list_subscribers", nil)
 
-	var subs []map[string]any
-	toolResult(t, resp, &subs)
+	var envelope map[string]any
+	toolResult(t, resp, &envelope)
+	subs, _ := envelope["subscribers"].([]any)
 	assert.Len(t, subs, 2, "list_subscribers must return 2 subscribers")
 }
 


### PR DESCRIPTION
## Summary

- Wrap all `list_*` tool responses in JSON envelope objects (`{peers:[...]}, {scenarios:[...]}, ...`) — required for Claude Code MCP client compatibility
- Add `get_peer` name-based lookup (accepts either `id` or `name`)
- Add `wait_execution` tool — blocks on SSE Subscribe channel until session reaches a terminal state, with configurable timeout
- Add `get_step_detail` tool — returns structured `{code, name, value}` AVP breakdown for a single CCR/CCA step
- Enhance `get_avp_info` to return `children` array for Grouped AVPs, allowing callers to inspect grouped AVP contents (e.g. `IN-Information`, `SMS-Information`) without external reference material

## Test plan

- [ ] All 34 MCP tools exercised end-to-end against a live server (peers, subscribers, scenarios, executions, AVP, system)
- [ ] Unit tests added for `wait_execution`, `get_step_detail`, and all envelope-wrapped list handlers
- [ ] `make test` passes (all packages green)
- [ ] `get_avp_info` returns `children` for `IN-Information` (16 children) and `SMS-Information` (20 children)