### PR TITLE
chore: upgrade agentic framework to v2.8.5

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   pipeline:
-    uses: eddiecarpenter/gh-agentic/.github/workflows/agentic-pipeline.yml@v2.8.3
+    uses: eddiecarpenter/gh-agentic/.github/workflows/agentic-pipeline.yml@v2.8.5
     with:
       pr_number: ${{ inputs.pr_number || '' }}
       branch_name: ${{ inputs.branch_name || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    uses: eddiecarpenter/gh-agentic/.github/workflows/release.yml@v2.8.3
+    uses: eddiecarpenter/gh-agentic/.github/workflows/release.yml@v2.8.5
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Bumps `gh-agentic` from v2.8.3 → v2.8.5 in both `agentic-pipeline.yml` and `release.yml`
- v2.8.5 fixes the `libvulkan.so.1` missing shared library error that caused Goose to fail to start on the self-hosted runner

## Test plan
- [ ] Merge and verify the next pipeline run for #178 starts Goose successfully