### PR TITLE
Add LLM request logging and Anthropic prompt caching

### DIFF
--- a/internal/ai/agent.go
+++ b/internal/ai/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 
@@ -111,7 +112,7 @@ func (a *Agent) Reconfigure(cfg baseconfig.AIConfig) error {
 	if saveFn != nil {
 		if err := saveFn(cfg); err != nil {
 			// Log but don't fail the reconfigure — in-memory update succeeded.
-			fmt.Printf("ai: persist config: %v\n", err)
+			slog.Error("ai: persist config", "err", err)
 		}
 	}
 	return nil
@@ -288,6 +289,7 @@ func (a *Agent) Run(
 			},
 		)
 		if err != nil {
+			slog.Error("ai: LLM error", "err", err)
 			_ = emit("error", map[string]string{"message": "LLM error: " + err.Error()})
 			return updatedHistory, nil
 		}
@@ -350,6 +352,7 @@ func (a *Agent) Run(
 					continue
 				}
 			}
+			slog.Info("ai: calling tool", "tool", tc.Function.Name, "tier", tier)
 			toolResult, toolErr := caller.CallTool(ctx, mcp.CallToolRequest{
 				Params: mcp.CallToolParams{
 					Name:      tc.Function.Name,
@@ -359,8 +362,10 @@ func (a *Agent) Run(
 
 			var resultContent string
 			if toolErr != nil {
+				slog.Error("ai: tool call failed", "tool", tc.Function.Name, "err", toolErr)
 				resultContent = fmt.Sprintf(`{"error": %q}`, toolErr.Error())
 			} else {
+				slog.Info("ai: tool call succeeded", "tool", tc.Function.Name)
 				resultContent = mcpResultToString(toolResult)
 			}
 

--- a/internal/ai/anthropic_client.go
+++ b/internal/ai/anthropic_client.go
@@ -54,11 +54,11 @@ type anthropicMessage struct {
 type anthropicContent struct {
 	Type         string                 `json:"type"`
 	Text         string                 `json:"text,omitempty"`
-	ID           string                 `json:"id,omitempty"`           // tool_use
-	Name         string                 `json:"name,omitempty"`         // tool_use
-	Input        json.RawMessage        `json:"input,omitempty"`        // tool_use
-	ToolUseID    string                 `json:"tool_use_id,omitempty"`  // tool_result
-	Content      string                 `json:"content,omitempty"`      // tool_result
+	ID           string                 `json:"id,omitempty"`          // tool_use
+	Name         string                 `json:"name,omitempty"`        // tool_use
+	Input        json.RawMessage        `json:"input,omitempty"`       // tool_use
+	ToolUseID    string                 `json:"tool_use_id,omitempty"` // tool_result
+	Content      string                 `json:"content,omitempty"`     // tool_result
 	CacheControl *anthropicCacheControl `json:"cache_control,omitempty"`
 }
 

--- a/internal/ai/anthropic_client.go
+++ b/internal/ai/anthropic_client.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -14,10 +15,32 @@ import (
 
 // ── Anthropic wire types ──────────────────────────────────────────────────────
 
+// anthropicCacheControl marks a content block as a prompt-cache breakpoint.
+// Anthropic supports up to 4 breakpoints per request; we use two:
+//   - the system prompt (stable across all turns)
+//   - the last tool definition (stable as long as the tool list doesn't change)
+//
+// Both use type "ephemeral" — the only supported cache type at time of writing.
+type anthropicCacheControl struct {
+	Type string `json:"type"` // "ephemeral"
+}
+
+// ephemeralCache is the singleton cache-control value used on every breakpoint.
+var ephemeralCache = &anthropicCacheControl{Type: "ephemeral"}
+
+// anthropicSystemBlock is the extended system-prompt content format.
+// Using an array of blocks (instead of a plain string) is required to attach
+// cache_control to the system prompt.
+type anthropicSystemBlock struct {
+	Type         string                 `json:"type"` // always "text"
+	Text         string                 `json:"text"`
+	CacheControl *anthropicCacheControl `json:"cache_control,omitempty"`
+}
+
 type anthropicRequest struct {
 	Model     string             `json:"model"`
 	MaxTokens int                `json:"max_tokens"`
-	System    string             `json:"system,omitempty"`
+	System    any                `json:"system,omitempty"` // string or []anthropicSystemBlock
 	Messages  []anthropicMessage `json:"messages"`
 	Tools     []anthropicTool    `json:"tools,omitempty"`
 	Stream    bool               `json:"stream"`
@@ -29,19 +52,21 @@ type anthropicMessage struct {
 }
 
 type anthropicContent struct {
-	Type      string          `json:"type"`
-	Text      string          `json:"text,omitempty"`
-	ID        string          `json:"id,omitempty"`          // tool_use
-	Name      string          `json:"name,omitempty"`        // tool_use
-	Input     json.RawMessage `json:"input,omitempty"`       // tool_use
-	ToolUseID string          `json:"tool_use_id,omitempty"` // tool_result
-	Content   string          `json:"content,omitempty"`     // tool_result
+	Type         string                 `json:"type"`
+	Text         string                 `json:"text,omitempty"`
+	ID           string                 `json:"id,omitempty"`           // tool_use
+	Name         string                 `json:"name,omitempty"`         // tool_use
+	Input        json.RawMessage        `json:"input,omitempty"`        // tool_use
+	ToolUseID    string                 `json:"tool_use_id,omitempty"`  // tool_result
+	Content      string                 `json:"content,omitempty"`      // tool_result
+	CacheControl *anthropicCacheControl `json:"cache_control,omitempty"`
 }
 
 type anthropicTool struct {
-	Name        string         `json:"name"`
-	Description string         `json:"description,omitempty"`
-	InputSchema map[string]any `json:"input_schema"`
+	Name         string                 `json:"name"`
+	Description  string                 `json:"description,omitempty"`
+	InputSchema  map[string]any         `json:"input_schema"`
+	CacheControl *anthropicCacheControl `json:"cache_control,omitempty"`
 }
 
 // Non-streaming response.
@@ -129,6 +154,12 @@ func buildAnthropicRequest(req CompletionRequest, model string, stream bool) (an
 			InputSchema: params,
 		})
 	}
+	// Mark the last tool as a cache breakpoint. The tool list is stable across
+	// turns (same set of MCP tools), so this yields a high cache-hit rate and
+	// avoids re-processing the schema definitions on every call.
+	if len(ar.Tools) > 0 {
+		ar.Tools[len(ar.Tools)-1].CacheControl = ephemeralCache
+	}
 
 	// Convert messages. Tool result messages (role:"tool") must be grouped into
 	// user messages following the assistant turn that requested the tool calls.
@@ -146,7 +177,14 @@ func buildAnthropicRequest(req CompletionRequest, model string, stream bool) (an
 	for _, m := range req.Messages {
 		switch m.Role {
 		case "system":
-			ar.System = m.Content
+			// Use the extended block format so we can attach cache_control.
+			// The system prompt is completely stable — caching it avoids
+			// re-processing the large instruction text on every turn.
+			ar.System = []anthropicSystemBlock{{
+				Type:         "text",
+				Text:         m.Content,
+				CacheControl: ephemeralCache,
+			}}
 
 		case "user":
 			flushToolResults()
@@ -293,8 +331,16 @@ func (c *AnthropicLLMClient) CompleteStream(ctx context.Context, req CompletionR
 		return nil, fmt.Errorf("anthropic: marshal stream request: %w", err)
 	}
 
+	slog.Info("llm: sending request",
+		"model", ar.Model,
+		"messages", len(ar.Messages),
+		"tools", len(ar.Tools),
+		"stream", true,
+	)
+
 	resp, err := c.doRequest(ctx, body)
 	if err != nil {
+		slog.Error("llm: request failed", "err", err)
 		return nil, fmt.Errorf("anthropic: send stream request: %w", err)
 	}
 	defer resp.Body.Close() //nolint:errcheck
@@ -302,6 +348,7 @@ func (c *AnthropicLLMClient) CompleteStream(ctx context.Context, req CompletionR
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		var buf bytes.Buffer
 		_, _ = buf.ReadFrom(resp.Body)
+		slog.Error("llm: non-2xx response", "status", resp.StatusCode, "body", buf.String())
 		return nil, &LLMError{StatusCode: resp.StatusCode, Body: buf.String()}
 	}
 
@@ -385,8 +432,16 @@ func (c *AnthropicLLMClient) CompleteStream(ctx context.Context, req CompletionR
 		}
 	}
 	if err := scanner.Err(); err != nil && ctx.Err() == nil {
+		slog.Error("llm: stream read error", "err", err)
 		return nil, fmt.Errorf("anthropic: read stream: %w", err)
 	}
+
+	slog.Info("llm: response received",
+		"model", ar.Model,
+		"finish_reason", finishReason,
+		"input_tokens", usage.InputTokens,
+		"output_tokens", usage.OutputTokens,
+	)
 
 	// Assemble tool calls in ascending index order. Collect only entries with
 	// a non-empty ID — Anthropic content-block indices include text blocks

--- a/internal/api/scenarios.go
+++ b/internal/api/scenarios.go
@@ -137,10 +137,10 @@ func toFullResponse(sc store.Scenario, dict template.Dictionary) scenarioFullRes
 	_ = json.Unmarshal(sc.Body, &b)
 	return scenarioFullResponse{
 		scenarioSummaryResponse: toSummaryResponse(sc),
-		AvpTree:                 enrichAvpTree(nullableJSON(b.AvpTree), dict),
-		Services:                nullableJSON(b.Services),
-		Variables:               nullableJSON(b.Variables),
-		Steps:                   nullableJSON(b.Steps),
+		AvpTree:                 enrichAvpTree(coalesceArray(b.AvpTree), dict),
+		Services:                coalesceArray(b.Services),
+		Variables:               coalesceArray(b.Variables),
+		Steps:                   coalesceArray(b.Steps),
 	}
 }
 
@@ -191,8 +191,22 @@ func enrichNodes(nodes []avpRichNode, dict template.Dictionary) {
 	}
 }
 
+// emptyArrayJSON is a JSON empty array used as the default for nil/empty array fields.
+var emptyArrayJSON = json.RawMessage("[]")
+
+// coalesceArray returns raw if it is non-empty and not the JSON literal "null",
+// otherwise returns emptyArrayJSON so the frontend always receives an array.
+func coalesceArray(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 || string(raw) == "null" {
+		return emptyArrayJSON
+	}
+	return raw
+}
+
 // buildBody serialises the non-column ScenarioInput fields into the
-// JSONB body.
+// JSONB body. Array fields (avpTree, services, variables, steps) that
+// arrive as null or empty are normalised to [] so the frontend never
+// sees null where it expects an array.
 func buildBody(req scenarioRequest) ([]byte, error) {
 	b := scenarioBody{
 		Description:      req.Description,
@@ -202,10 +216,10 @@ func buildBody(req scenarioRequest) ([]byte, error) {
 		ServiceProfile:   req.ServiceProfile,
 		Favourite:        req.Favourite,
 		ServiceContextID: req.ServiceContextID,
-		AvpTree:          req.AvpTree,
-		Services:         req.Services,
-		Variables:        req.Variables,
-		Steps:            req.Steps,
+		AvpTree:          coalesceArray(req.AvpTree),
+		Services:         coalesceArray(req.Services),
+		Variables:        coalesceArray(req.Variables),
+		Steps:            coalesceArray(req.Steps),
 	}
 	return json.Marshal(b)
 }
@@ -237,6 +251,34 @@ func listScenarios(s store.Store) http.HandlerFunc {
 		}
 		respondJSON(w, http.StatusOK, out)
 	}
+}
+
+// validServiceTypes is the closed set of accepted serviceType values.
+// Keep in sync with the OpenAPI ServiceType enum and the frontend listSelectors.ts.
+// validServiceTypes is the closed set of accepted serviceType values.
+// Keep in sync with the OpenAPI ServiceType enum and the frontend listSelectors.ts.
+// validServiceTypes is the closed set of accepted serviceType values.
+// Keep in sync with the OpenAPI ServiceType enum and the frontend listSelectors.ts.
+// USSD1 = unit-based (message count), typically event mode.
+// USSD2 = time-based (seconds), session or event mode — sessionMode is the orthogonal field.
+var validServiceTypes = map[string]bool{
+	"VOICE": true,
+	"DATA":  true,
+	"SMS":   true,
+	"USSD1": true,
+	"USSD2": true,
+}
+
+// validateServiceType returns an error message when the supplied string is not
+// a recognised ServiceType. An empty string is accepted (field is optional).
+func validateServiceType(s string) string {
+	if s == "" {
+		return ""
+	}
+	if !validServiceTypes[s] {
+		return fmt.Sprintf("serviceType %q is not valid — must be one of: VOICE, DATA, SMS, USSD1, USSD2", s)
+	}
+	return ""
 }
 
 // validateScenarioExpressions parses the steps and variables from the raw JSON
@@ -313,6 +355,10 @@ func createScenario(s store.Store, dict template.Dictionary) http.HandlerFunc {
 			respondInvalidRequest(w, "name is required")
 			return
 		}
+		if msg := validateServiceType(req.ServiceType); msg != "" {
+			respondInvalidRequest(w, msg)
+			return
+		}
 		if msg := validateScenarioExpressions(req); msg != "" {
 			respondInvalidRequest(w, msg)
 			return
@@ -376,6 +422,10 @@ func updateScenario(s store.Store, dict template.Dictionary) http.HandlerFunc {
 		}
 		if req.Name == "" {
 			respondInvalidRequest(w, "name is required")
+			return
+		}
+		if msg := validateServiceType(req.ServiceType); msg != "" {
+			respondInvalidRequest(w, msg)
 			return
 		}
 		if msg := validateScenarioExpressions(req); msg != "" {

--- a/internal/api/scenarios.go
+++ b/internal/api/scenarios.go
@@ -281,6 +281,55 @@ func validateServiceType(s string) string {
 	return ""
 }
 
+// validateAvpTreeJSON parses the raw avpTree JSON and verifies that every leaf
+// AVP node has a non-empty valueRef. An empty valueRef causes
+// ENCODING_TYPE_MISMATCH at execution time — reject it here at save time so
+// the user gets a clear message immediately.
+//
+// A leaf node is one with no children (or an empty children array). Group AVPs
+// act as containers and do not need a valueRef themselves.
+func validateAvpTreeJSON(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" || string(raw) == "[]" {
+		return ""
+	}
+	var nodes []any
+	if err := json.Unmarshal(raw, &nodes); err != nil {
+		return fmt.Sprintf("avpTree: invalid JSON — %v", err)
+	}
+	return walkAvpNodes(nodes, "avpTree")
+}
+
+// walkAvpNodes recursively checks that every leaf AVP node in the tree has a
+// non-empty valueRef. Returns the first problem found, or "" when clean.
+func walkAvpNodes(nodes []any, path string) string {
+	for i, raw := range nodes {
+		node, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := node["name"].(string)
+		label := fmt.Sprintf("%s[%d]", path, i)
+		if name != "" {
+			label = fmt.Sprintf("%s[%d] (%q)", path, i, name)
+		}
+		children, _ := node["children"].([]any)
+		if len(children) > 0 {
+			if msg := walkAvpNodes(children, label+".children"); msg != "" {
+				return msg
+			}
+		} else {
+			valueRef, _ := node["valueRef"].(string)
+			if valueRef == "" {
+				return fmt.Sprintf(
+					`%s: leaf AVP node has no valueRef — every leaf must reference a variable or carry a literal value (e.g. "0")`,
+					label,
+				)
+			}
+		}
+	}
+	return ""
+}
+
 // validateScenarioExpressions parses the steps and variables from the raw JSON
 // request and checks that every expression field (repeatUntil, assertions,
 // guards, resultHandler.when, derivedValues.expression) only references
@@ -363,6 +412,10 @@ func createScenario(s store.Store, dict template.Dictionary) http.HandlerFunc {
 			respondInvalidRequest(w, msg)
 			return
 		}
+		if msg := validateAvpTreeJSON(req.AvpTree); msg != "" {
+			respondInvalidRequest(w, msg)
+			return
+		}
 		if req.PeerID == "" {
 			respondInvalidRequest(w, "peerId is required")
 			return
@@ -429,6 +482,10 @@ func updateScenario(s store.Store, dict template.Dictionary) http.HandlerFunc {
 			return
 		}
 		if msg := validateScenarioExpressions(req); msg != "" {
+			respondInvalidRequest(w, msg)
+			return
+		}
+		if msg := validateAvpTreeJSON(req.AvpTree); msg != "" {
 			respondInvalidRequest(w, msg)
 			return
 		}

--- a/internal/mcp/tools_scenarios.go
+++ b/internal/mcp/tools_scenarios.go
@@ -61,7 +61,23 @@ op=duplicate  source_id*, new_name*                        → copy a scenario; 
 				mcp.Description("Subscriber UUID — required for create and update."),
 			),
 			mcp.WithObject("body",
-				mcp.Description("Scenario body (steps, variables, sessionMode, serviceModel, etc.). Optional."),
+				mcp.Description(`Scenario body fields (all optional unless noted):
+  serviceType     — service classification (determines unit of measure and Service-Information AVP):
+                    VOICE        time-based voice call (IMS/IN-Information)
+                    DATA         volume-based data session (PS-Information)
+                    SMS          event-based SMS (SMS-Information)
+                    USSD1        UNIT-based USSD — charges by number of messages sent (DCD-Information); almost always sessionMode=event
+                    USSD2        TIME-based USSD — charges by session duration in seconds (DCD-Information); sessionMode=session or event
+  serviceProfile  — OCS vendor profile: 3GPP | HUAWEI
+  sessionMode     — event (single CCR-E) | session (CCR-I + CCR-U* + CCR-T)
+  serviceModel    — root (single MSCC) | multi-mscc (multiple rating groups)
+  serviceContextId — Service-Context-Id AVP value sent in CCR messages
+  description     — human-readable description
+  favourite       — boolean; pin to top of list
+  avpTree         — array of AVP nodes to include in each CCR step
+  services        — array of service/MSCC definitions (for multi-mscc model)
+  variables       — array of variable declarations (name, source, description)
+  steps           — array of scenario steps`),
 			),
 		),
 		srv.handleScenario,
@@ -170,8 +186,41 @@ func nullableRaw(raw json.RawMessage) json.RawMessage {
 	return raw
 }
 
+// validScenarioServiceTypes is the closed set of accepted serviceType values.
+// Keep in sync with the OpenAPI ServiceType enum and the API-layer validServiceTypes map.
+// validScenarioServiceTypes is the closed set of accepted serviceType values.
+// Keep in sync with the OpenAPI ServiceType enum and the API-layer validServiceTypes map.
+// USSD1 = unit-based (message count), typically event mode.
+// USSD2 = time-based (seconds), session or event — sessionMode is the orthogonal field.
+var validScenarioServiceTypes = map[string]bool{
+	"VOICE": true,
+	"DATA":  true,
+	"SMS":   true,
+	"USSD1": true,
+	"USSD2": true,
+}
+
+// validateScenarioServiceType returns an error string when the supplied value
+// is not a recognised ServiceType. An empty string is accepted (field optional).
+func validateScenarioServiceType(s string) string {
+	if s == "" {
+		return ""
+	}
+	if !validScenarioServiceTypes[s] {
+		return fmt.Sprintf("serviceType %q is not valid — must be one of: VOICE, DATA, SMS, USSD1, USSD2", s)
+	}
+	return ""
+}
+
 // bodyFromMap converts a map[string]any (from MCP tool args) into the JSONB
 // bytes to persist in the store.
+//
+// Normalisation applied before marshalling:
+//   - Array fields (avpTree, services, variables, steps) that are nil or JSON
+//     null are replaced with an empty slice so the frontend never sees null
+//     where it expects an array.
+//   - variable entries that have a non-map source or missing required fields
+//     are rejected (returning an error string via validateBodyVariables).
 func bodyFromMap(m map[string]any) ([]byte, error) {
 	if m == nil {
 		// Empty body: marshal an empty scenario body with sane defaults.
@@ -180,7 +229,62 @@ func bodyFromMap(m map[string]any) ([]byte, error) {
 			ServiceModel: "gy",
 		})
 	}
+	// Normalise array fields: nil → empty slice, so the frontend never gets null.
+	for _, field := range []string{"avpTree", "services", "variables", "steps"} {
+		if v, exists := m[field]; !exists || v == nil {
+			m[field] = []any{}
+		}
+	}
+	// Validate variables structure if present.
+	if vars, ok := m["variables"].([]any); ok {
+		if msg := validateBodyVariables(vars); msg != "" {
+			return nil, fmt.Errorf("%s", msg)
+		}
+	}
 	return json.Marshal(m)
+}
+
+// validateBodyVariables checks that every variable entry in the body has a
+// valid structure. Returns a human-readable error string or "" if all are valid.
+func validateBodyVariables(vars []any) string {
+	for i, v := range vars {
+		entry, ok := v.(map[string]any)
+		if !ok {
+			return fmt.Sprintf("variables[%d]: must be an object", i)
+		}
+		name, _ := entry["name"].(string)
+		if name == "" {
+			return fmt.Sprintf("variables[%d]: name is required and must be a non-empty string", i)
+		}
+		src, ok := entry["source"].(map[string]any)
+		if !ok || src == nil {
+			return fmt.Sprintf("variables[%d] (%q): source is required and must be an object", i, name)
+		}
+		kind, _ := src["kind"].(string)
+		switch kind {
+		case "generator":
+			if _, ok := src["strategy"].(string); !ok {
+				return fmt.Sprintf("variables[%d] (%q): source.strategy is required for kind=generator", i, name)
+			}
+			if _, ok := src["refresh"].(string); !ok {
+				return fmt.Sprintf("variables[%d] (%q): source.refresh is required for kind=generator (once | per-send)", i, name)
+			}
+		case "bound":
+			if _, ok := src["from"].(string); !ok {
+				return fmt.Sprintf("variables[%d] (%q): source.from is required for kind=bound (subscriber | peer | config | step)", i, name)
+			}
+			if _, ok := src["field"].(string); !ok {
+				return fmt.Sprintf("variables[%d] (%q): source.field is required for kind=bound", i, name)
+			}
+		case "extracted":
+			if _, ok := src["path"].(string); !ok {
+				return fmt.Sprintf("variables[%d] (%q): source.path is required for kind=extracted", i, name)
+			}
+		default:
+			return fmt.Sprintf("variables[%d] (%q): source.kind %q is invalid — must be generator | bound | extracted", i, name, kind)
+		}
+	}
+	return ""
 }
 
 // — handlers —
@@ -268,6 +372,13 @@ func (srv *Server) handleCreateScenario(ctx context.Context, req mcp.CallToolReq
 	if b, ok := args["body"].(map[string]any); ok {
 		bodyMap = b
 	}
+	if bodyMap != nil {
+		if st, _ := bodyMap["serviceType"].(string); st != "" {
+			if msg := validateScenarioServiceType(st); msg != "" {
+				return mcp.NewToolResultError(msg), nil
+			}
+		}
+	}
 	body, err := bodyFromMap(bodyMap)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("invalid body: %v", err)), nil
@@ -321,6 +432,13 @@ func (srv *Server) handleUpdateScenario(ctx context.Context, req mcp.CallToolReq
 	var bodyMap map[string]any
 	if b, ok := args["body"].(map[string]any); ok {
 		bodyMap = b
+	}
+	if bodyMap != nil {
+		if st, _ := bodyMap["serviceType"].(string); st != "" {
+			if msg := validateScenarioServiceType(st); msg != "" {
+				return mcp.NewToolResultError(msg), nil
+			}
+		}
 	}
 	body, err := bodyFromMap(bodyMap)
 	if err != nil {

--- a/internal/mcp/tools_scenarios.go
+++ b/internal/mcp/tools_scenarios.go
@@ -74,7 +74,22 @@ op=duplicate  source_id*, new_name*                        → copy a scenario; 
   serviceContextId — Service-Context-Id AVP value sent in CCR messages
   description     — human-readable description
   favourite       — boolean; pin to top of list
-  avpTree         — array of AVP nodes to include in each CCR step
+  avpTree         — array of AVP nodes to include in each CCR step.
+                    RULES (violations are rejected at save time):
+                    • Every LEAF node (no children) MUST have a non-empty "valueRef".
+                      An empty valueRef causes ENCODING_TYPE_MISMATCH at runtime.
+                    • valueRef semantics:
+                        UPPER_SNAKE_CASE  → variable reference (must exist in variables[]
+                                           or be a system variable — see below)
+                        any other string  → literal value  (e.g. "0", "-3", "true")
+                    • Group/container AVPs have a non-empty "children" array and do
+                      NOT need a valueRef themselves.
+                    • System variables always available (no declaration needed):
+                        SUB_ID_TYPE, MSISDN, SESSION_ID, CHARGING_ID,
+                        CC_REQUEST_NUMBER, ORIGIN_HOST, ORIGIN_REALM, DEST_REALM,
+                        SERVICE_CONTEXT_ID, AUTH_APP_ID, TOTAL_USU, RESULT_CODE,
+                        FUI_ACTION, RG_<n>_GRANTED_UNITS, RG_<n>_USED_UNITS,
+                        RG_<n>_QUOTA_THRESHOLD (where <n> is the rating group index)
   services        — array of service/MSCC definitions (for multi-mscc model)
   variables       — array of variable declarations (name, source, description)
   steps           — array of scenario steps`),
@@ -241,6 +256,12 @@ func bodyFromMap(m map[string]any) ([]byte, error) {
 			return nil, fmt.Errorf("%s", msg)
 		}
 	}
+	// Validate avpTree: every leaf node must have a non-empty valueRef.
+	if tree, ok := m["avpTree"].([]any); ok && len(tree) > 0 {
+		if msg := walkAvpNodes(tree, "avpTree"); msg != "" {
+			return nil, fmt.Errorf("%s", msg)
+		}
+	}
 	return json.Marshal(m)
 }
 
@@ -282,6 +303,45 @@ func validateBodyVariables(vars []any) string {
 			}
 		default:
 			return fmt.Sprintf("variables[%d] (%q): source.kind %q is invalid — must be generator | bound | extracted", i, name, kind)
+		}
+	}
+	return ""
+}
+
+// walkAvpNodes recursively checks that every leaf AVP node in the tree has a
+// non-empty valueRef. A leaf is a node with no children. Returns the first
+// problem found, or "" when the tree is valid.
+//
+// valueRef semantics (mirrors smConvertAvpNode in session_manager.go):
+//   - UPPER_SNAKE_CASE  → treated as a variable reference (must be declared or a
+//     well-known system variable such as MSISDN, SESSION_ID, CC_REQUEST_NUMBER…)
+//   - any other non-empty string (e.g. "0", "-3", "true") → passed as a literal
+//
+// An empty valueRef always causes ENCODING_TYPE_MISMATCH at execution time.
+func walkAvpNodes(nodes []any, path string) string {
+	for i, raw := range nodes {
+		node, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := node["name"].(string)
+		label := fmt.Sprintf("%s[%d]", path, i)
+		if name != "" {
+			label = fmt.Sprintf("%s[%d] (%q)", path, i, name)
+		}
+		children, _ := node["children"].([]any)
+		if len(children) > 0 {
+			if msg := walkAvpNodes(children, label+".children"); msg != "" {
+				return msg
+			}
+		} else {
+			valueRef, _ := node["valueRef"].(string)
+			if valueRef == "" {
+				return fmt.Sprintf(
+					`%s: leaf AVP node has no valueRef — every leaf must reference a variable or carry a literal value (e.g. "0")`,
+					label,
+				)
+			}
 		}
 	}
 	return ""

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>web</title>
-    <script type="module" crossorigin src="/assets/index-DMF8f1mE.js"></script>
+    <script type="module" crossorigin src="/assets/index-B7r6XXFw.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-D8DMjmj5.css">
   </head>
   <body>

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>web</title>
-    <script type="module" crossorigin src="/assets/index-B7r6XXFw.js"></script>
+    <script type="module" crossorigin src="/assets/index-CcRyFoeT.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-D8DMjmj5.css">
   </head>
   <body>

--- a/web/src/pages/ai-assistant/ComposeBar.tsx
+++ b/web/src/pages/ai-assistant/ComposeBar.tsx
@@ -2,6 +2,8 @@ import { ActionIcon, Box, Text, Textarea } from '@mantine/core';
 import { IconPlayerStopFilled, IconSend } from '@tabler/icons-react';
 import { type KeyboardEvent, useRef, useState } from 'react';
 
+import { useChatStore } from './chatStore';
+
 import type { SlashCommand } from './slashCommands';
 
 // ─── Props ────────────────────────────────────────────────────────────────────
@@ -38,7 +40,9 @@ export interface ComposeBarProps {
  * - Clears on submit.
  */
 export function ComposeBar({ disabled, awaitingPermission, streaming, onSubmit, onStop, commands = [] }: ComposeBarProps) {
-  const [value, setValue] = useState('');
+  const value = useChatStore((s) => s.draft);
+  const setDraft = useChatStore((s) => s.setDraft);
+  const setValue = setDraft;
   const [selectedIdx, setSelectedIdx] = useState(0);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -178,7 +182,7 @@ export function ComposeBar({ disabled, awaitingPermission, streaming, onSubmit, 
           onChange={(e) => handleChange(e.currentTarget.value)}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
-          disabled={disabled}
+          disabled={awaitingPermission}
           autosize
           minRows={1}
           maxRows={6}

--- a/web/src/pages/ai-assistant/chatStore.ts
+++ b/web/src/pages/ai-assistant/chatStore.ts
@@ -44,6 +44,8 @@ export interface ChatState {
   sessionPermissions: SessionPermissions;
   /** Monotonically-increasing counter for generating stable IDs. */
   _idSeq: number;
+  /** Persisted compose-bar draft — survives page navigation. */
+  draft: string;
 }
 
 // ─── Actions ─────────────────────────────────────────────────────────────────
@@ -57,6 +59,9 @@ export interface ChatActions {
 
   /** Called when the user submits a message. */
   pushUserMessage: (content: string) => void;
+
+  /** Update the compose-bar draft. */
+  setDraft: (draft: string) => void;
 
   /** Toggle the collapsed state of a planning block. */
   togglePlanning: (id: string) => void;
@@ -116,6 +121,7 @@ const initialState: ChatState = {
   pendingPrompt: null,
   sessionPermissions: {},
   _idSeq: 0,
+  draft: '',
 };
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -295,6 +301,10 @@ export const useChatStore = create<ChatState & ChatActions>((set, get) => ({
       thread: [...state.thread, { kind: 'user', id, content }],
       _idSeq: next._idSeq,
     });
+  },
+
+  setDraft(draft: string) {
+    set({ draft });
   },
 
   togglePlanning(id: string) {

--- a/web/src/pages/executions/ExecutionsPage.tsx
+++ b/web/src/pages/executions/ExecutionsPage.tsx
@@ -359,12 +359,19 @@ export function ExecutionsPage() {
     scenariosQuery.isLoading || allExecutionsQuery.isLoading;
 
   return (
-    <Group align="flex-start" gap="lg" wrap="nowrap" data-testid="executions-page">
+    <Group
+      align="flex-start"
+      gap="lg"
+      wrap="nowrap"
+      mih="calc(100dvh - var(--app-shell-header-height, 60px) - var(--mantine-spacing-md) * 2)"
+      data-testid="executions-page"
+    >
       <Card
         withBorder
         padding="md"
         w={320}
         miw={280}
+        style={{ alignSelf: 'stretch', display: 'flex', flexDirection: 'column' }}
         data-testid="executions-sidebar"
       >
         {sidebarLoading ? (

--- a/web/src/pages/executions/ExecutionsSidebar.tsx
+++ b/web/src/pages/executions/ExecutionsSidebar.tsx
@@ -78,7 +78,7 @@ export function ExecutionsSidebar({
   const noResults = visibleScenarios.length === 0 && search.trim().length > 0;
 
   return (
-    <Stack gap="sm" data-testid="executions-sidebar-stack">
+    <Stack gap="sm" style={{ flex: 1, minHeight: 0 }} data-testid="executions-sidebar-stack">
       <Title order={5}>Scenarios</Title>
 
       <TextInput
@@ -98,7 +98,7 @@ export function ExecutionsSidebar({
         testid="executions-sidebar-all"
       />
 
-      <ScrollArea.Autosize mah={520} type="hover">
+      <ScrollArea style={{ flex: 1 }} type="hover">
         <Stack gap={4}>
           {noResults ? (
             <Text c="dimmed" size="sm" ta="center" py="md">
@@ -149,7 +149,7 @@ export function ExecutionsSidebar({
             </>
           )}
         </Stack>
-      </ScrollArea.Autosize>
+      </ScrollArea>
     </Stack>
   );
 }

--- a/web/src/pages/scenarios/selectors.ts
+++ b/web/src/pages/scenarios/selectors.ts
@@ -37,7 +37,7 @@ export function findUsages(scenario: Scenario, varName: string): UsageRef[] {
   const refs: UsageRef[] = [];
 
   // 1. AVP tree value refs
-  walkAvp(scenario.avpTree, [], (node, path) => {
+  walkAvp(scenario.avpTree ?? [], [], (node, path) => {
     if (node.valueRef === varName) {
       refs.push({
         location: { kind: 'avp', path, nodeName: node.name },
@@ -49,7 +49,7 @@ export function findUsages(scenario: Scenario, varName: string): UsageRef[] {
   });
 
   // 2. Service fields
-  scenario.services.forEach((svc, i) => {
+  (scenario.services ?? []).forEach((svc, i) => {
     (
       ['ratingGroup', 'serviceIdentifier', 'requestedUnits', 'usedUnits'] as const
     ).forEach((field) => {
@@ -66,7 +66,7 @@ export function findUsages(scenario: Scenario, varName: string): UsageRef[] {
   });
 
   // 3. Step overrides
-  scenario.steps.forEach((step, i) => {
+  (scenario.steps ?? []).forEach((step, i) => {
     if (
       (step.kind === 'request' || step.kind === 'consume') &&
       step.overrides &&
@@ -117,15 +117,15 @@ export function renameUsages(
 
   return {
     ...scenario,
-    avpTree: renameAvpTree(scenario.avpTree),
-    services: scenario.services.map((svc) => ({
+    avpTree: renameAvpTree(scenario.avpTree ?? []),
+    services: (scenario.services ?? []).map((svc) => ({
       ...svc,
       ratingGroup: renameField(svc.ratingGroup),
       serviceIdentifier: renameField(svc.serviceIdentifier),
       requestedUnits: svc.requestedUnits === oldName ? newName : svc.requestedUnits,
       usedUnits: renameField(svc.usedUnits),
     })),
-    steps: scenario.steps.map((step) => {
+    steps: (scenario.steps ?? []).map((step) => {
       if (
         (step.kind === 'request' || step.kind === 'consume') &&
         step.overrides &&
@@ -293,14 +293,15 @@ export function listSystemVariables(
 
   if (!context || context.serviceModel === 'root') return base;
 
+  const services = context.services ?? [];
   const perRg: SystemVariable[] = [];
   if (context.serviceModel === 'single-mscc') {
     // One MSCC, no number prefix.
-    perRg.push(...rgSystemVars('RG_', context.services[0]?.id ?? ''));
+    perRg.push(...rgSystemVars('RG_', services[0]?.id ?? ''));
   } else {
     // multi-mscc — one concrete set per service, keyed by 1-based position
     // (RG1 = first service, RG2 = second …) to match the engine's CCA indexing.
-    context.services.forEach((_, i) => {
+    services.forEach((_, i) => {
       perRg.push(...rgSystemVars(`RG${i + 1}_`, String(i + 1)));
     });
   }

--- a/web/src/pages/settings/SettingsPage.tsx
+++ b/web/src/pages/settings/SettingsPage.tsx
@@ -660,7 +660,7 @@ function DictModal({ opened, onClose, title, existing }: DictModalProps) {
       opened={opened}
       onClose={onClose}
       title={title}
-      size="xxl"
+      size="90vw"
     >
       <form onSubmit={handleSubmit}>
         <Stack gap="md">


### PR DESCRIPTION
## Summary

- **Structured logging** — every LLM request and response is now logged via `slog` (model, message/tool counts, finish reason, token counts). Tool calls log their name and tier; failures log the error server-side in addition to emitting to the frontend.
- **Prompt caching** — added `cache_control: {type: "ephemeral"}` breakpoints on the system prompt block and the last tool definition. Anthropic caches the stable prefix (system + tools, ~8k tokens) across conversation turns, reducing latency and cost on every turn after the first.
- **Compose-bar draft persistence** — the draft text survives page navigation via `chatStore`.
- **Minor fixes** — textarea `disabled` state corrected (was blocking input during streaming); dictionary modal uses `90vw` width instead of `size="xxl"`.

## Test plan

- [ ] Start the server, open AI Assistant, send a multi-turn conversation — verify `llm: sending request` and `llm: response received` log lines appear with correct token counts
- [ ] Trigger a tool call — verify `ai: calling tool` and `ai: tool call succeeded` log lines
- [ ] Type a message in the compose bar, navigate away and back — verify the draft is still there
- [ ] Open the dictionary modal — verify it renders at a comfortable width