### PR TITLE
Align USSD service type enum to USSD1/USSD2

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1622,15 +1622,18 @@ components:
         mode, and the Service-Information child AVP injected by the engine.
         Combined with `serviceProfile` for the AVP code mapping.
 
-        | Value         | Unit type | Session mode | Service-Info child              |
-        |---------------|-----------|--------------|----------------------------------|
-        | VOICE         | TIME      | session      | IMS-Information / IN_INFORMATION |
-        | DATA          | VOLUME    | session      | PS-Information (both profiles)   |
-        | SMS           | EVENT     | session      | SMS-Information / SMS_INFORMATION|
-        | USSD1_EVENT   | EVENT     | event        | USSD-Information / DCD_INFORMATION|
-        | USSD1_SESSION | EVENT     | session      | USSD-Information / DCD_INFORMATION|
-        | USSD2_SESSION | TIME      | session      | USSD-Information / DCD_INFORMATION|
-      enum: [VOICE, DATA, SMS, USSD1_EVENT, USSD1_SESSION, USSD2_SESSION]
+        | Value | Unit type | Session mode         | Service-Info child              |
+        |-------|-----------|----------------------|----------------------------------|
+        | VOICE | TIME      | session              | IMS-Information / IN_INFORMATION |
+        | DATA  | VOLUME    | session              | PS-Information (both profiles)   |
+        | SMS   | EVENT     | session              | SMS-Information / SMS_INFORMATION|
+        | USSD1 | EVENT     | event (almost always)| USSD-Information / DCD_INFORMATION|
+        | USSD2 | TIME      | session or event     | USSD-Information / DCD_INFORMATION|
+
+        USSD1 charges by number of messages sent (unit-based).
+        USSD2 charges by session duration in seconds (time-based).
+        Session mode is controlled separately via `sessionMode`.
+      enum: [VOICE, DATA, SMS, USSD1, USSD2]
 
     ServiceProfile:
       type: string
@@ -1642,13 +1645,13 @@ components:
         - VOICE         → IMS-Information (876)
         - DATA          → PS-Information (874)
         - SMS           → SMS-Information (2000)
-        - USSD1_EVENT, USSD1_SESSION, USSD2_SESSION → USSD-Information (885)
+        - USSD1, USSD2  → USSD-Information (885)
 
         **HUAWEI** (Huawei-specific AVPs use vendor-id 2011):
         - VOICE         → IN_INFORMATION (20300)
         - DATA          → PS-Information (874, vendor 10415)
         - SMS           → SMS_INFORMATION (20400)
-        - USSD1_EVENT, USSD1_SESSION, USSD2_SESSION → DCD_INFORMATION (2115)
+        - USSD1, USSD2  → DCD_INFORMATION (2115)
       enum: [3GPP, HUAWEI]
       default: 3GPP
 

--- a/web/src/api/schema.d.ts
+++ b/web/src/api/schema.d.ts
@@ -1035,17 +1035,20 @@ export interface components {
          *     mode, and the Service-Information child AVP injected by the engine.
          *     Combined with `serviceProfile` for the AVP code mapping.
          *
-         *     | Value         | Unit type | Session mode | Service-Info child              |
-         *     |---------------|-----------|--------------|----------------------------------|
-         *     | VOICE         | TIME      | session      | IMS-Information / IN_INFORMATION |
-         *     | DATA          | VOLUME    | session      | PS-Information (both profiles)   |
-         *     | SMS           | EVENT     | session      | SMS-Information / SMS_INFORMATION|
-         *     | USSD1_EVENT   | EVENT     | event        | USSD-Information / DCD_INFORMATION|
-         *     | USSD1_SESSION | EVENT     | session      | USSD-Information / DCD_INFORMATION|
-         *     | USSD2_SESSION | TIME      | session      | USSD-Information / DCD_INFORMATION|
+         *     | Value | Unit type | Session mode         | Service-Info child              |
+         *     |-------|-----------|----------------------|----------------------------------|
+         *     | VOICE | TIME      | session              | IMS-Information / IN_INFORMATION |
+         *     | DATA  | VOLUME    | session              | PS-Information (both profiles)   |
+         *     | SMS   | EVENT     | session              | SMS-Information / SMS_INFORMATION|
+         *     | USSD1 | EVENT     | event (almost always)| USSD-Information / DCD_INFORMATION|
+         *     | USSD2 | TIME      | session or event     | USSD-Information / DCD_INFORMATION|
+         *
+         *     USSD1 charges by number of messages sent (unit-based).
+         *     USSD2 charges by session duration in seconds (time-based).
+         *     Session mode is controlled separately via `sessionMode`.
          * @enum {string}
          */
-        ServiceType: "VOICE" | "DATA" | "SMS" | "USSD1_EVENT" | "USSD1_SESSION" | "USSD2_SESSION";
+        ServiceType: "VOICE" | "DATA" | "SMS" | "USSD1" | "USSD2";
         /**
          * @description OCS vendor profile. Selects the AVP code mapping for the
          *     `serviceType` → `Service-Information` child AVP.
@@ -1054,13 +1057,13 @@ export interface components {
          *     - VOICE         → IMS-Information (876)
          *     - DATA          → PS-Information (874)
          *     - SMS           → SMS-Information (2000)
-         *     - USSD1_EVENT, USSD1_SESSION, USSD2_SESSION → USSD-Information (885)
+         *     - USSD1, USSD2  → USSD-Information (885)
          *
          *     **HUAWEI** (Huawei-specific AVPs use vendor-id 2011):
          *     - VOICE         → IN_INFORMATION (20300)
          *     - DATA          → PS-Information (874, vendor 10415)
          *     - SMS           → SMS_INFORMATION (20400)
-         *     - USSD1_EVENT, USSD1_SESSION, USSD2_SESSION → DCD_INFORMATION (2115)
+         *     - USSD1, USSD2  → DCD_INFORMATION (2115)
          * @default 3GPP
          * @enum {string}
          */

--- a/web/src/pages/scenarios/BuilderHeader.tsx
+++ b/web/src/pages/scenarios/BuilderHeader.tsx
@@ -48,9 +48,8 @@ const SERVICE_TYPE_OPTIONS: { value: ServiceType; label: string }[] = [
   { value: 'VOICE', label: 'Voice' },
   { value: 'DATA', label: 'Data' },
   { value: 'SMS', label: 'SMS' },
-  { value: 'USSD1_EVENT', label: 'USSD1 Event' },
-  { value: 'USSD1_SESSION', label: 'USSD1 Session' },
-  { value: 'USSD2_SESSION', label: 'USSD2 Session' },
+  { value: 'USSD1', label: 'USSD1 (Unit)' },
+  { value: 'USSD2', label: 'USSD2 (Time)' },
 ];
 
 const SESSION_OPTIONS: { value: SessionMode; label: string }[] = [

--- a/web/src/pages/scenarios/defaults.ts
+++ b/web/src/pages/scenarios/defaults.ts
@@ -16,7 +16,7 @@ import type {
 
 /** Default session mode implied by each service type. */
 export function defaultSessionMode(serviceType: ServiceType | undefined): SessionMode {
-  return serviceType === 'USSD1_EVENT' ? 'event' : 'session';
+  return serviceType === 'USSD1' ? 'event' : 'session';
 }
 
 /** Default steps for a given session mode. */
@@ -73,9 +73,8 @@ function build3GPPChildren(serviceType: ServiceType): AvpNode[] {
       return [{ name: 'PS-Information',   code: 874,  vendorId: 10415, locked: true }];
     case 'SMS':
       return [{ name: 'SMS-Information',  code: 2000, vendorId: 10415, locked: true }];
-    case 'USSD1_EVENT':
-    case 'USSD1_SESSION':
-    case 'USSD2_SESSION':
+    case 'USSD1':
+    case 'USSD2':
       return [{ name: 'USSD-Information', code: 885,  vendorId: 10415, locked: true }];
     default:
       return [];
@@ -109,9 +108,8 @@ function buildHuaweiChildren(serviceType: ServiceType): AvpNode[] {
       return [{ name: 'PS-Information',  code: 874,   vendorId: 10415, locked: true }];
     case 'SMS':
       return [{ name: 'SMS-Information', code: 20327, vendorId: 2011, locked: true }];
-    case 'USSD1_EVENT':
-    case 'USSD1_SESSION':
-    case 'USSD2_SESSION':
+    case 'USSD1':
+    case 'USSD2':
       return [{ name: 'DCD-Information', code: 20337, vendorId: 2011, locked: true }];
     default:
       return [];

--- a/web/src/pages/scenarios/listSelectors.ts
+++ b/web/src/pages/scenarios/listSelectors.ts
@@ -6,16 +6,15 @@
 import type { ScenarioSummary, ServiceType } from './types';
 
 export const SERVICE_TYPE_GROUP_ORDER: ServiceType[] = [
-  'VOICE', 'DATA', 'SMS', 'USSD1_EVENT', 'USSD1_SESSION', 'USSD2_SESSION',
+  'VOICE', 'DATA', 'SMS', 'USSD1', 'USSD2',
 ];
 
 export const SERVICE_TYPE_LABELS: Record<ServiceType, string> = {
   VOICE: 'Voice',
   DATA: 'Data',
   SMS: 'SMS',
-  USSD1_EVENT: 'USSD1 Event',
-  USSD1_SESSION: 'USSD1 Session',
-  USSD2_SESSION: 'USSD2 Session',
+  USSD1: 'USSD1 (Unit)',
+  USSD2: 'USSD2 (Time)',
 };
 
 const UNGROUPED = '__ungrouped__' as const;

--- a/web/src/pages/scenarios/validators.ts
+++ b/web/src/pages/scenarios/validators.ts
@@ -23,7 +23,7 @@ export interface MatrixCell {
 export function deriveUnitType(serviceType: ServiceType | undefined): UnitType {
   switch (serviceType) {
     case 'VOICE':
-    case 'USSD2_SESSION':
+    case 'USSD2':
       return 'TIME';
     case 'DATA':
       return 'VOLUME';


### PR DESCRIPTION
## Summary
- Renames `USSD1_EVENT`/`USSD1_SESSION`/`USSD2_SESSION` → `USSD1`/`USSD2` in the OpenAPI spec, generated TS types, and all frontend files
- `sessionMode` is already the orthogonal field for event vs session behaviour — encoding it in the service type name was redundant
- Fixes blank Scenarios page caused by `groupByServiceType` crashing on unknown enum values at runtime

## Test plan
- [ ] Scenarios page renders all service type groups (VOICE, DATA, SMS, USSD1, USSD2)
- [ ] Builder header service type dropdown shows USSD1 (Unit) and USSD2 (Time)
- [ ] Existing USSD2 scenarios load and save correctly